### PR TITLE
id-class-value

### DIFF
--- a/src/rules/id-class-value.js
+++ b/src/rules/id-class-value.js
@@ -30,6 +30,9 @@ HTMLHint.addRule({
         if(rule && rule.regId){
             var regId = rule.regId,
                 message = rule.message;
+            if(!(regId instanceof RegExp)) {
+                regId = new RegExp(regId);
+            }
             parser.addListener('tagstart', function(event){
                 var attrs = event.attrs,
                     attr,

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -14,7 +14,7 @@ ruleOptionsUnderline[ruldId] = 'underline';
 ruleOptionsDash[ruldId] = 'dash';
 ruleOptionsHump[ruldId] = 'hump';
 ruleOptionsReg[ruldId] = {
-        'regId': /^_[a-z\d]+(-[a-z\d]+)*$/,
+        'regId': '^_[a-z\d]+(-[a-z\d]+)*$',
         'message': 'Id and class value must meet regexp'
     };
 


### PR DESCRIPTION
Add ability to pass regexp in `.htmlhintrc` file for matching attributes value.

Example:
```js
...
"id-class-value": {
    "regId": "^[a-z\\d]+([-_]+[a-z\\d]+)*$",
    "message": "The id and class attribute values must be in lowercase and split by dash or underscore"
},
...
```

Problem was in parsing config file by `JSON.parse`. We can not correct pass `regexp` into json schema. Only `string`. And this `string` after parsing is `string` too. 

I just check input data. If it is not regexp then create `new RegExp` instance from input string.