### PR TITLE
Used Object.keys instead of Object.values

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -143,8 +143,8 @@ function repeatStr(n, str) {
 }
 
 const hint = new HTMLHint();
-Object.values(HTMLRules).forEach(rule => {
-  hint.addRule(rule);
+Object.keys(HTMLRules).forEach(key => {
+  hint.addRule(HTMLRules[key]);
 });
 export default hint;
 export { HTMLRules, Reporter, HTMLParser, HTMLHint };


### PR DESCRIPTION
Fixes #345

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:
HTMLhint does not work with nodejs v7, this fix resolves that.

#### Proposed changes:
Propose change is using Object.keys instead of Object.values, it is a very simple fix that will make HTMLhint usable by companies who are currently on nodejs v7 and 6.