### PR TITLE
feat(htmlhint): add RegExp and regex string

### DIFF
--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -46,4 +46,18 @@ describe(`Rules: ${ruldId}`, function() {
     const messages = HTMLHint.verify(code, ruleOptions);
     expect(messages.length).to.be(0);
   });
+
+  it('Set to array list with RegExp should not result in an error', function() {
+    const code = '<p testBox="abc" bind:tapTop="ccc">';
+    ruleOptions[ruldId] = ['testBox', /bind:.*/];
+    const messages = HTMLHint.verify(code, ruleOptions);
+    expect(messages.length).to.be(0);
+  });
+
+  it('Set to array list with regex string should not result in an error', function() {
+    const code = '<p testBox="abc" [ngFor]="ccc">';
+    ruleOptions[ruldId] = ['testBox', '/\\[.*\\]/'];
+    const messages = HTMLHint.verify(code, ruleOptions);
+    expect(messages.length).to.be(0);
+  });
 });


### PR DESCRIPTION
**Fixes**: #228 #183  microsoft/vscode-htmlhint#34

🚨 Please review the [guidelines for contributing](CONTRIBUTING.md) and our [code of conduct](../CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

#### Proposed changes: 

## -  RegExp and regex string can be used in whitelist now

```html
<p bind:tapTop="onTapTop" bind:moveBack="onBack"></p>
```
```json
{
  "attr-lowercase" : ["/bind:.*/"]
}
```
will ignore all attributes  ` bind:*` now

The regex string configuration was referenced from stylelint.
