### PR TITLE
fix: wrong named export

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -9,7 +9,7 @@ var glob = require("glob");
 var parseGlob = require('parse-glob');
 var request = require('request');
 
-var HTMLHint  = require("../dist/htmlhint.js").hint;
+var HTMLHint  = require("../dist/htmlhint.js").HTMLHint;
 var formatter = require('./formatter');
 var pkg = require('../package.json');
 


### PR DESCRIPTION
#### Short description of what this resolves:

HTMLHint was undefined.

#### Proposed changes:

Update named export from `hint` to `HTMLHint`
