### PR TITLE
fix: dist generate htmlhint

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "prettier": "prettier --write ./**/*.{js,json,md} --ignore-path ./.prettierignore",
     "test": "mocha --recursive \"./test/**/*.spec.js\"",
     "build": "npm run build:min && npm run build:unmin",
-    "build:min": "rollup -c --environment NODE_ENV:production",
-    "build:unmin": "rollup -c --environment NODE_ENV:production --file dist/htmlhint.min.js"
+    "build:min": "rollup -c --environment NODE_ENV:production --file dist/htmlhint.min.js",
+    "build:unmin": "rollup -c"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**Short description of what this resolves:**

Build script only generating minified version

#### Proposed changes:

Remove `--environment NODE_ENV:production` from `build:unmin` script