### PR TITLE
feat: added attr-no-unnecessary-whitespace rule

### DIFF
--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -1,0 +1,24 @@
+HTMLHint.addRule({
+    id: 'attr-no-unnecessary-whitespace',
+    description: 'No spaces between attribute names and values.',
+    init: function(parser, reporter, options){
+        var self = this;
+        var exceptions = Array.isArray(options) ? options : [];
+        parser.addListener('tagstart', function(event){
+            var attrs = event.attrs,
+                col = event.col + event.tagName.length + 1;
+            for(var i = 0; i < attrs.length; i++){
+                console.log(attrs[i]);
+                if (exceptions.indexOf(attrs[i].name) === -1 && /[^=](\s+=\s+|=\s+|\s+=)/g.test(attrs[i].raw.trim())) {
+                    reporter.error(
+                        'The attribute \'' + attrs[i].name + '\' must not have spaces between the name and value.',
+                        event.line,
+                        col + attrs[i].index,
+                        self,
+                        attrs[i].raw
+                    );
+                }
+            }
+        });
+    }
+});

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -1,14 +1,13 @@
 HTMLHint.addRule({
     id: 'attr-no-unnecessary-whitespace',
     description: 'No spaces between attribute names and values.',
-    init: function(parser, reporter, options){
+    init: function (parser, reporter, options) {
         var self = this;
         var exceptions = Array.isArray(options) ? options : [];
-        parser.addListener('tagstart', function(event){
+        parser.addListener('tagstart', function (event) {
             var attrs = event.attrs,
                 col = event.col + event.tagName.length + 1;
-            for(var i = 0; i < attrs.length; i++){
-                console.log(attrs[i]);
+            for (var i = 0; i < attrs.length; i++) {
                 if (exceptions.indexOf(attrs[i].name) === -1 && /[^=](\s+=\s+|=\s+|\s+=)/g.test(attrs[i].raw.trim())) {
                     reporter.error(
                         'The attribute \'' + attrs[i].name + '\' must not have spaces between the name and value.',

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -1,4 +1,4 @@
-HTMLHint.addRule({
+export default {
     id: 'attr-no-unnecessary-whitespace',
     description: 'No spaces between attribute names and values.',
     init: function (parser, reporter, options) {
@@ -20,4 +20,4 @@ HTMLHint.addRule({
             }
         });
     }
-});
+};

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -27,3 +27,4 @@ export { default as tagnameLowercase } from './tagname-lowercase';
 export { default as tagnameSpecialChars } from './tagname-specialchars';
 export { default as titleRequire } from './title-require';
 export { default as tagsCheck } from './tags-check';
+export { default as attrNoUnnecessaryWhitespace } from './attr-no-unnecessary-whitespace';

--- a/test/rules/attr-no-unnecessary-whitespace.js
+++ b/test/rules/attr-no-unnecessary-whitespace.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js');
 
-var HTMLHint = require('../../index').HTMLHint;
+var HTMLHint = require('../../dist/htmlhint.js').HTMLHint;
 
 var ruldId = 'attr-no-unnecessary-whitespace',
     ruleOptions = {};

--- a/test/rules/attr-no-unnecessary-whitespace.js
+++ b/test/rules/attr-no-unnecessary-whitespace.js
@@ -1,0 +1,31 @@
+var expect = require('expect.js');
+
+var HTMLHint = require('../../index').HTMLHint;
+
+var ruldId = 'attr-no-unnecessary-whitespace',
+    ruleOptions = {};
+
+ruleOptions[ruldId] = true;
+
+describe('Rules: ' + ruldId, function () {
+    it('Attribute with spaces should result in an error', function () {
+        var codes = [
+            '<div title = "a" />',
+            '<div title= "a" />',
+            '<div title ="a" />',
+        ];
+        for (var i = 0; i < codes.length; i++) {
+            var messages = HTMLHint.verify(codes[i], ruleOptions);
+            expect(messages.length).to.be(1);
+            expect(messages[0].rule.id).to.be(ruldId);
+            expect(messages[0].line).to.be(1);
+            expect(messages[0].col).to.be(5);
+        }
+    });
+
+    it('Attribute without spaces should not result in an error', function () {
+        var code = '<div title="a" />';
+        var messages = HTMLHint.verify(code, ruleOptions);
+        expect(messages.length).to.be(0);
+    });
+});


### PR DESCRIPTION
Initial PR done by @jakewtaylor #220

Shows an error like:
`The attribute 'name' must not have spaces between the name and value.`
for code like:
```
type = "text"
type ="text"
type= "text"
```
This is valid:
```
type="text"
```