### PR TITLE
chore: modernize code / prefer arrow functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,5 +12,6 @@ module.exports = {
   },
   rules: {
     'one-var': ['error', 'never'],
+    'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    'arrow-body-style': ['error'],
     'one-var': ['error', 'never'],
     'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
   },

--- a/bin/formatter.js
+++ b/bin/formatter.js
@@ -29,7 +29,7 @@ function loadFormatters() {
   })
 
   var mapFormatters = {}
-  arrFiles.forEach(function (file) {
+  arrFiles.forEach((file) => {
     var fileInfo = path.parse(file)
     var formatterPath = path.resolve(__dirname, file)
     mapFormatters[fileInfo.name] = require(formatterPath)

--- a/bin/formatters/checkstyle.js
+++ b/bin/formatters/checkstyle.js
@@ -1,15 +1,15 @@
 var xml = require('xml')
 
 var checkstyleFormatter = function (formatter) {
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var arrFiles = []
     var arrAllMessages = event.arrAllMessages
 
-    arrAllMessages.forEach(function (fileInfo) {
+    arrAllMessages.forEach((fileInfo) => {
       var arrMessages = fileInfo.messages
       var arrErrors = []
 
-      arrMessages.forEach(function (message) {
+      arrMessages.forEach((message) => {
         arrErrors.push({
           error: {
             _attr: {

--- a/bin/formatters/compact.js
+++ b/bin/formatters/compact.js
@@ -1,8 +1,8 @@
 var compactFormatter = function (formatter, HTMLHint, options) {
   var nocolor = options.nocolor
 
-  formatter.on('file', function (event) {
-    event.messages.forEach(function (message) {
+  formatter.on('file', (event) => {
+    event.messages.forEach((message) => {
       console.log(
         '%s: line %d, col %d, %s - %s (%s)',
         event.file,
@@ -15,7 +15,7 @@ var compactFormatter = function (formatter, HTMLHint, options) {
     })
   })
 
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var allHintCount = event.allHintCount
     if (allHintCount > 0) {
       console.log('')

--- a/bin/formatters/default.js
+++ b/bin/formatters/default.js
@@ -1,17 +1,17 @@
 var defaultFormatter = function (formatter, HTMLHint, options) {
   var nocolor = options.nocolor
 
-  formatter.on('start', function () {
+  formatter.on('start', () => {
     console.log('')
   })
 
-  formatter.on('config', function (event) {
+  formatter.on('config', (event) => {
     var configPath = event.configPath
     console.log('   Config loaded: %s', nocolor ? configPath : configPath.cyan)
     console.log('')
   })
 
-  formatter.on('file', function (event) {
+  formatter.on('file', (event) => {
     console.log('   ' + event.file.white)
 
     var arrLogs = HTMLHint.format(event.messages, {
@@ -19,14 +19,14 @@ var defaultFormatter = function (formatter, HTMLHint, options) {
       indent: 6,
     })
 
-    arrLogs.forEach(function (str) {
+    arrLogs.forEach((str) => {
       console.log(str)
     })
 
     console.log('')
   })
 
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var allFileCount = event.allFileCount
     var allHintCount = event.allHintCount
     var allHintFileCount = event.allHintFileCount

--- a/bin/formatters/html.js
+++ b/bin/formatters/html.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 
 var htmlFormatter = function (formatter) {
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var fileContent
     fileContent = '<html>'
     fileContent =
@@ -15,9 +15,9 @@ var htmlFormatter = function (formatter) {
       '<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>'
 
     var arrAllMessages = event.arrAllMessages
-    arrAllMessages.forEach(function (fileInfo) {
+    arrAllMessages.forEach((fileInfo) => {
       var arrMessages = fileInfo.messages
-      arrMessages.forEach(function (message, i) {
+      arrMessages.forEach((message, i) => {
         fileContent =
           fileContent +
           '<tr><td>' +

--- a/bin/formatters/json.js
+++ b/bin/formatters/json.js
@@ -1,5 +1,5 @@
 var jsonFormatter = function (formatter) {
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     console.log(JSON.stringify(event.arrAllMessages))
   })
 }

--- a/bin/formatters/junit.js
+++ b/bin/formatters/junit.js
@@ -1,11 +1,11 @@
 var xml = require('xml')
 
 var junitFormatter = function (formatter, HTMLHint) {
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var arrTestcase = []
     var arrAllMessages = event.arrAllMessages
 
-    arrAllMessages.forEach(function (fileInfo) {
+    arrAllMessages.forEach((fileInfo) => {
       var arrMessages = fileInfo.messages
       var arrLogs = HTMLHint.format(arrMessages)
 

--- a/bin/formatters/markdown.js
+++ b/bin/formatters/markdown.js
@@ -1,18 +1,18 @@
 var markdownFormatter = function (formatter, HTMLHint) {
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     console.log('# TOC')
 
     var arrToc = []
     var arrContents = []
     var arrAllMessages = event.arrAllMessages
 
-    arrAllMessages.forEach(function (fileInfo) {
+    arrAllMessages.forEach((fileInfo) => {
       var filePath = fileInfo.file
       var arrMessages = fileInfo.messages
       var errorCount = 0
       var warningCount = 0
 
-      arrMessages.forEach(function (message) {
+      arrMessages.forEach((message) => {
         if (message.type === 'error') {
           errorCount++
         } else {
@@ -30,7 +30,7 @@ var markdownFormatter = function (formatter, HTMLHint) {
 
       var arrLogs = HTMLHint.format(arrMessages)
       arrContents.push('')
-      arrLogs.forEach(function (log) {
+      arrLogs.forEach((log) => {
         arrContents.push('    ' + log)
       })
       arrContents.push('')

--- a/bin/formatters/unix.js
+++ b/bin/formatters/unix.js
@@ -1,7 +1,7 @@
 var unixFormatter = function (formatter, HTMLHint, options) {
   var nocolor = options.nocolor
-  formatter.on('file', function (event) {
-    event.messages.forEach(function (message) {
+  formatter.on('file', (event) => {
+    event.messages.forEach((message) => {
       console.log(
         [
           event.file,
@@ -19,7 +19,7 @@ var unixFormatter = function (formatter, HTMLHint, options) {
     })
   })
 
-  formatter.on('end', function (event) {
+  formatter.on('end', (event) => {
     var allHintCount = event.allHintCount
     if (allHintCount > 0) {
       console.log('')

--- a/src/core.js
+++ b/src/core.js
@@ -37,7 +37,7 @@ class HTMLHintCore {
         }
 
         strRuleset.replace(
-          // eslint-disable-next-line
+          // eslint-disable-next-line no-useless-escape
           /(?:^|,)\s*([^:,]+)\s*(?:\:\s*([^,\s]+))?/g,
           (all, key, value) => {
             if (value === 'false') {
@@ -131,7 +131,7 @@ class HTMLHintCore {
       // show pointer & message
       var pointCol = col - leftCol
       // add double byte character
-      //eslint-disable-next-line
+      // eslint-disable-next-line no-control-regex
       var match = evidence.substring(0, pointCol).match(/[^\u0000-\u00ff]/g)
       if (match !== null) {
         pointCol += match.length

--- a/src/core.js
+++ b/src/core.js
@@ -29,30 +29,29 @@ class HTMLHintCore {
     }
 
     // parse inline ruleset
-    html = html.replace(/^\s*<!--\s*htmlhint\s+([^\r\n]+?)\s*-->/i, function (
-      all,
-      strRuleset
-    ) {
-      if (ruleset === undefined) {
-        ruleset = {}
-      }
-
-      // eslint-disable-next-line
-      strRuleset.replace(/(?:^|,)\s*([^:,]+)\s*(?:\:\s*([^,\s]+))?/g, function (
-        all,
-        key,
-        value
-      ) {
-        if (value === 'false') {
-          value = false
-        } else if (value === 'true') {
-          value = true
+    html = html.replace(
+      /^\s*<!--\s*htmlhint\s+([^\r\n]+?)\s*-->/i,
+      (all, strRuleset) => {
+        if (ruleset === undefined) {
+          ruleset = {}
         }
-        ruleset[key] = value === undefined ? true : value
-      })
 
-      return ''
-    })
+        strRuleset.replace(
+          // eslint-disable-next-line
+          /(?:^|,)\s*([^:,]+)\s*(?:\:\s*([^,\s]+))?/g,
+          (all, key, value) => {
+            if (value === 'false') {
+              value = false
+            } else if (value === 'true') {
+              value = true
+            }
+            ruleset[key] = value === undefined ? true : value
+          }
+        )
+
+        return ''
+      }
+    )
 
     var parser = new HTMLParser()
     var reporter = new Reporter(html, ruleset)

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -18,8 +18,7 @@ class HTMLParser {
   }
 
   parse(html) {
-    var self = this
-    var mapCdataTags = self._mapCdataTags
+    var mapCdataTags = this._mapCdataTags
 
     // eslint-disable-next-line
     var regTag = /<(?:\/([^\s>]+)\s*|!--([\s\S]*?)--|!([^>]*?)|([\w\-:]+)((?:\s+[^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]*))?)*?)\s*(\/?))>/g,
@@ -39,16 +38,16 @@ class HTMLParser {
     var text
     var lastLineIndex = 0
     var line = 1
-    var arrBlocks = self._arrBlocks
+    var arrBlocks = this._arrBlocks
 
-    self.fire('start', {
+    this.fire('start', {
       pos: 0,
       line: 1,
       col: 1,
     })
 
     // Memory block
-    function saveBlock(type, raw, pos, data) {
+    var saveBlock = (type, raw, pos, data) => {
       var col = pos - lastLineIndex + 1
       if (data === undefined) {
         data = {}
@@ -58,7 +57,7 @@ class HTMLParser {
       data.line = line
       data.col = col
       arrBlocks.push(data)
-      self.fire(type, data)
+      this.fire(type, data)
 
       // eslint-disable-next-line
       var lineMatch
@@ -172,7 +171,7 @@ class HTMLParser {
       saveBlock('text', text, lastIndex)
     }
 
-    self.fire('end', {
+    this.fire('end', {
       pos: lastIndex,
       line: line,
       col: html.length - lastLineIndex + 1,
@@ -198,10 +197,10 @@ class HTMLParser {
       data = {}
     }
     data.type = type
-    var self = this
+
     var listeners = []
-    var listenersType = self._listeners[type]
-    var listenersAll = self._listeners['all']
+    var listenersType = this._listeners[type]
+    var listenersAll = this._listeners['all']
 
     if (listenersType !== undefined) {
       listeners = listeners.concat(listenersType)
@@ -210,16 +209,16 @@ class HTMLParser {
       listeners = listeners.concat(listenersAll)
     }
 
-    var lastEvent = self.lastEvent
+    var lastEvent = this.lastEvent
     if (lastEvent !== null) {
       delete lastEvent['lastEvent']
       data.lastEvent = lastEvent
     }
 
-    self.lastEvent = data
+    this.lastEvent = data
 
     for (var i = 0, l = listeners.length; i < l; i++) {
-      listeners[i].call(self, data)
+      listeners[i].call(this, data)
     }
   }
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -20,11 +20,11 @@ class HTMLParser {
   parse(html) {
     var mapCdataTags = this._mapCdataTags
 
-    // eslint-disable-next-line
-    var regTag = /<(?:\/([^\s>]+)\s*|!--([\s\S]*?)--|!([^>]*?)|([\w\-:]+)((?:\s+[^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]*))?)*?)\s*(\/?))>/g,
-      // eslint-disable-next-line
-      regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g,
-      regLine = /\r?\n/g
+    // eslint-disable-next-line no-control-regex, no-useless-escape
+    var regTag = /<(?:\/([^\s>]+)\s*|!--([\s\S]*?)--|!([^>]*?)|([\w\-:]+)((?:\s+[^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]*))?)*?)\s*(\/?))>/g
+    // eslint-disable-next-line no-control-regex, no-useless-escape
+    var regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g
+    var regLine = /\r?\n/g
 
     var match
     var matchIndex
@@ -59,7 +59,7 @@ class HTMLParser {
       arrBlocks.push(data)
       this.fire(type, data)
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-unused-vars
       var lineMatch
       while ((lineMatch = regLine.exec(raw))) {
         line++

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -14,9 +14,8 @@ class Reporter {
   }
 
   report(type, message, line, col, rule, raw) {
-    var self = this
-    var lines = self.lines
-    var brLen = self.brLen
+    var lines = this.lines
+    var brLen = this.brLen
     var evidence
     var evidenceLen
 
@@ -34,7 +33,7 @@ class Reporter {
       }
     }
 
-    self.messages.push({
+    this.messages.push({
       type: type,
       message: message,
       raw: raw,

--- a/src/rules/alt-require.js
+++ b/src/rules/alt-require.js
@@ -4,7 +4,7 @@ export default {
     'The alt attribute of an <img> element must be present and alt attribute of area[href] and input[type=image] must have a value.',
   init: function (parser, reporter) {
     var self = this
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var tagName = event.tagName.toLowerCase()
       var mapAttrs = parser.getMapAttrs(event.attrs)
       var col = event.col + tagName.length + 1

--- a/src/rules/alt-require.js
+++ b/src/rules/alt-require.js
@@ -2,8 +2,7 @@ export default {
   id: 'alt-require',
   description:
     'The alt attribute of an <img> element must be present and alt attribute of area[href] and input[type=image] must have a value.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var tagName = event.tagName.toLowerCase()
       var mapAttrs = parser.getMapAttrs(event.attrs)
@@ -15,7 +14,7 @@ export default {
           'An alt attribute must be present on <img> elements.',
           event.line,
           col,
-          self,
+          this,
           event.raw
         )
       } else if (
@@ -28,7 +27,7 @@ export default {
             'The alt attribute of ' + selector + ' must have a value.',
             event.line,
             col,
-            self,
+            this,
             event.raw
           )
         }

--- a/src/rules/attr-lowercase.js
+++ b/src/rules/attr-lowercase.js
@@ -41,8 +41,7 @@ function testAgainstStringOrRegExp(value, comparison) {
 export default {
   id: 'attr-lowercase',
   description: 'All attribute names must be in lowercase.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var exceptions = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart', (event) => {
@@ -62,7 +61,7 @@ export default {
             'The attribute name of [ ' + attrName + ' ] must be in lowercase.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-lowercase.js
+++ b/src/rules/attr-lowercase.js
@@ -45,7 +45,7 @@ export default {
     var self = this
     var exceptions = Array.isArray(options) ? options : []
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/attr-no-duplication.js
+++ b/src/rules/attr-no-duplication.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var attrName

--- a/src/rules/attr-no-duplication.js
+++ b/src/rules/attr-no-duplication.js
@@ -1,9 +1,7 @@
 export default {
   id: 'attr-no-duplication',
   description: 'Elements cannot have duplicate attributes.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -21,7 +19,7 @@ export default {
             'Duplicate of attribute name [ ' + attr.name + ' ] was found.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -5,7 +5,7 @@ export default {
     var self = this
     var exceptions = Array.isArray(options) ? options : []
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var col = event.col + event.tagName.length + 1
 

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -18,7 +18,7 @@ export default {
                 "' must not have spaces between the name and value.",
               event.line,
               col + attrs[i].index,
-              self,
+              this,
               attrs[i].raw
             )
           }

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -1,8 +1,7 @@
 export default {
   id: 'attr-no-unnecessary-whitespace',
   description: 'No spaces between attribute names and values.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var exceptions = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart', (event) => {

--- a/src/rules/attr-sorted.js
+++ b/src/rules/attr-sorted.js
@@ -1,8 +1,7 @@
 export default {
   id: 'attr-sorted',
   description: 'Attribute tags must be in proper order.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var orderMap = {}
     var sortOrder = [
       'class',
@@ -52,7 +51,7 @@ export default {
             ' ',
           event.line,
           event.col,
-          self
+          this
         )
       }
     })

--- a/src/rules/attr-sorted.js
+++ b/src/rules/attr-sorted.js
@@ -22,7 +22,7 @@ export default {
       orderMap[sortOrder[i]] = i
     }
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var listOfAttributes = []
 
@@ -31,7 +31,7 @@ export default {
       }
 
       var originalAttrs = JSON.stringify(listOfAttributes)
-      listOfAttributes.sort(function (a, b) {
+      listOfAttributes.sort((a, b) => {
         if (orderMap[a] == undefined && orderMap[b] == undefined) {
           return 0
         }

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -1,9 +1,7 @@
 export default {
   id: 'attr-unsafe-chars',
   description: 'Attribute values cannot contain unsafe chars.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -29,7 +27,7 @@ export default {
               ' ].',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -7,7 +7,7 @@ export default {
       var attr
       var col = event.col + event.tagName.length + 1
       // exclude \x09(\t), \x0a(\r), \x0d(\n)
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-misleading-character-class, no-control-regex
       var regUnsafe = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/
       var match
 

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/attr-value-double-quotes.js
+++ b/src/rules/attr-value-double-quotes.js
@@ -1,9 +1,7 @@
 export default {
   id: 'attr-value-double-quotes',
   description: 'Attribute values must be in double quotes.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -22,7 +20,7 @@ export default {
               ' ] must be in double quotes.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-value-double-quotes.js
+++ b/src/rules/attr-value-double-quotes.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/attr-value-not-empty.js
+++ b/src/rules/attr-value-not-empty.js
@@ -1,9 +1,7 @@
 export default {
   id: 'attr-value-not-empty',
   description: 'All attributes must have values.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -17,7 +15,7 @@ export default {
             'The attribute [ ' + attr.name + ' ] must have a value.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-value-not-empty.js
+++ b/src/rules/attr-value-not-empty.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/attr-value-single-quotes.js
+++ b/src/rules/attr-value-single-quotes.js
@@ -1,9 +1,7 @@
 export default {
   id: 'attr-value-single-quotes',
   description: 'Attribute values must be in single quotes.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -22,7 +20,7 @@ export default {
               ' ] must be in single quotes.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/attr-value-single-quotes.js
+++ b/src/rules/attr-value-single-quotes.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/attr-whitespace.js
+++ b/src/rules/attr-whitespace.js
@@ -6,12 +6,12 @@ export default {
     var self = this
     var exceptions = Array.isArray(options) ? options : []
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1
 
-      attrs.forEach(function (elem) {
+      attrs.forEach((elem) => {
         attr = elem
         var attrName = elem.name
 

--- a/src/rules/attr-whitespace.js
+++ b/src/rules/attr-whitespace.js
@@ -2,8 +2,7 @@ export default {
   id: 'attr-whitespace',
   description:
     'All attributes should be separated by only one space and not have leading/trailing whitespace.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var exceptions = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart', (event) => {
@@ -27,7 +26,7 @@ export default {
               ' ] must not have trailing whitespace.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }
@@ -39,7 +38,7 @@ export default {
               ' ] must be separated by only one space.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/doctype-first.js
+++ b/src/rules/doctype-first.js
@@ -1,10 +1,8 @@
 export default {
   id: 'doctype-first',
   description: 'Doctype must be declared first.',
-  init: function (parser, reporter) {
-    var self = this
-
-    var allEvent = function (event) {
+  init(parser, reporter) {
+    var allEvent = (event) => {
       if (
         event.type === 'start' ||
         (event.type === 'text' && /^\s*$/.test(event.raw))
@@ -20,7 +18,7 @@ export default {
           'Doctype must be declared first.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/doctype-html5.js
+++ b/src/rules/doctype-html5.js
@@ -17,7 +17,7 @@ export default {
       }
     }
 
-    function onTagStart() {
+    var onTagStart = () => {
       parser.removeListener('comment', onComment)
       parser.removeListener('tagstart', onTagStart)
     }

--- a/src/rules/doctype-html5.js
+++ b/src/rules/doctype-html5.js
@@ -1,10 +1,8 @@
 export default {
   id: 'doctype-html5',
   description: 'Invalid doctype. Use: "<!DOCTYPE html>"',
-  init: function (parser, reporter) {
-    var self = this
-
-    function onComment(event) {
+  init(parser, reporter) {
+    var onComment = (event) => {
       if (
         event.long === false &&
         event.content.toLowerCase() !== 'doctype html'
@@ -13,7 +11,7 @@ export default {
           'Invalid doctype. Use: "<!DOCTYPE html>"',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/head-script-disabled.js
+++ b/src/rules/head-script-disabled.js
@@ -1,12 +1,11 @@
 export default {
   id: 'head-script-disabled',
   description: 'The <script> tag cannot be used in a <head> tag.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var reScript = /^(text\/javascript|application\/javascript)$/i
     var isInHead = false
 
-    function onTagStart(event) {
+    var onTagStart = (event) => {
       var mapAttrs = parser.getMapAttrs(event.attrs)
       var type = mapAttrs.type
       var tagName = event.tagName.toLowerCase()
@@ -24,7 +23,7 @@ export default {
           'The <script> tag cannot be used in a <head> tag.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/head-script-disabled.js
+++ b/src/rules/head-script-disabled.js
@@ -29,7 +29,7 @@ export default {
       }
     }
 
-    function onTagEnd(event) {
+    var onTagEnd = (event) => {
       if (event.tagName.toLowerCase() === 'head') {
         parser.removeListener('tagstart', onTagStart)
         parser.removeListener('tagend', onTagEnd)

--- a/src/rules/href-abs-or-rel.js
+++ b/src/rules/href-abs-or-rel.js
@@ -6,7 +6,7 @@ export default {
 
     var hrefMode = options === 'abs' ? 'absolute' : 'relative'
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/href-abs-or-rel.js
+++ b/src/rules/href-abs-or-rel.js
@@ -1,9 +1,7 @@
 export default {
   id: 'href-abs-or-rel',
   description: 'An href attribute must be either absolute or relative.',
-  init: function (parser, reporter, options) {
-    var self = this
-
+  init(parser, reporter, options) {
     var hrefMode = options === 'abs' ? 'absolute' : 'relative'
 
     parser.addListener('tagstart', (event) => {
@@ -28,7 +26,7 @@ export default {
                 '.',
               event.line,
               col + attr.index,
-              self,
+              this,
               attr.raw
             )
           }

--- a/src/rules/id-class-ad-disabled.js
+++ b/src/rules/id-class-ad-disabled.js
@@ -5,7 +5,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var attrName

--- a/src/rules/id-class-ad-disabled.js
+++ b/src/rules/id-class-ad-disabled.js
@@ -2,9 +2,7 @@ export default {
   id: 'id-class-ad-disabled',
   description:
     'The id and class attributes cannot use the ad keyword, it will be blocked by adblock software.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -23,7 +21,7 @@ export default {
                 ' cannot use the ad keyword.',
               event.line,
               col + attr.index,
-              self,
+              this,
               attr.raw
             )
           }

--- a/src/rules/id-class-value.js
+++ b/src/rules/id-class-value.js
@@ -37,7 +37,7 @@ export default {
         regId = new RegExp(regId)
       }
 
-      parser.addListener('tagstart', function (event) {
+      parser.addListener('tagstart', (event) => {
         var attrs = event.attrs
         var attr
         var col = event.col + event.tagName.length + 1

--- a/src/rules/id-class-value.js
+++ b/src/rules/id-class-value.js
@@ -2,8 +2,7 @@ export default {
   id: 'id-class-value',
   description:
     'The id and class attribute values must meet the specified rules.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var arrRules = {
       underline: {
         regId: /^[a-z\d]+(_[a-z\d]+)*$/,
@@ -51,7 +50,7 @@ export default {
                 message,
                 event.line,
                 col + attr.index,
-                self,
+                this,
                 attr.raw
               )
             }
@@ -68,7 +67,7 @@ export default {
                   message,
                   event.line,
                   col + attr.index,
-                  self,
+                  this,
                   classValue
                 )
               }

--- a/src/rules/id-unique.js
+++ b/src/rules/id-unique.js
@@ -1,8 +1,7 @@
 export default {
   id: 'id-unique',
   description: 'The value of id attributes must be unique.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var mapIdCount = {}
 
     parser.addListener('tagstart', (event) => {
@@ -29,7 +28,7 @@ export default {
                 'The id value [ ' + id + ' ] must be unique.',
                 event.line,
                 col + attr.index,
-                self,
+                this,
                 attr.raw
               )
             }

--- a/src/rules/id-unique.js
+++ b/src/rules/id-unique.js
@@ -5,7 +5,7 @@ export default {
     var self = this
     var mapIdCount = {}
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var id

--- a/src/rules/inline-script-disabled.js
+++ b/src/rules/inline-script-disabled.js
@@ -1,9 +1,7 @@
 export default {
   id: 'inline-script-disabled',
   description: 'Inline script cannot be used.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -20,7 +18,7 @@ export default {
             'Inline script [ ' + attr.raw + ' ] cannot be used.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         } else if (attrName === 'src' || attrName === 'href') {
@@ -29,7 +27,7 @@ export default {
               'Inline script [ ' + attr.raw + ' ] cannot be used.',
               event.line,
               col + attr.index,
-              self,
+              this,
               attr.raw
             )
           }

--- a/src/rules/inline-script-disabled.js
+++ b/src/rules/inline-script-disabled.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/inline-style-disabled.js
+++ b/src/rules/inline-style-disabled.js
@@ -1,9 +1,7 @@
 export default {
   id: 'inline-style-disabled',
   description: 'Inline style cannot be used.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
@@ -17,7 +15,7 @@ export default {
             'Inline style [ ' + attr.raw + ' ] cannot be used.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/inline-style-disabled.js
+++ b/src/rules/inline-style-disabled.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var attr
       var col = event.col + event.tagName.length + 1

--- a/src/rules/input-requires-label.js
+++ b/src/rules/input-requires-label.js
@@ -1,8 +1,7 @@
 export default {
   id: 'input-requires-label',
   description: 'All [ input ] tags must have a corresponding [ label ] tag. ',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var labelTags = []
     var inputTags = []
 
@@ -29,7 +28,7 @@ export default {
             'No matching [ label ] tag found.',
             inputTag.event.line,
             inputTag.col,
-            self,
+            this,
             inputTag.event.raw
           )
         }

--- a/src/rules/input-requires-label.js
+++ b/src/rules/input-requires-label.js
@@ -6,7 +6,7 @@ export default {
     var labelTags = []
     var inputTags = []
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var tagName = event.tagName.toLowerCase()
       var mapAttrs = parser.getMapAttrs(event.attrs)
       var col = event.col + tagName.length + 1
@@ -22,8 +22,8 @@ export default {
       }
     })
 
-    parser.addListener('end', function () {
-      inputTags.forEach(function (inputTag) {
+    parser.addListener('end', () => {
+      inputTags.forEach((inputTag) => {
         if (!hasMatchingLabelTag(inputTag)) {
           reporter.warn(
             'No matching [ label ] tag found.',
@@ -38,7 +38,7 @@ export default {
 
     function hasMatchingLabelTag(inputTag) {
       var found = false
-      labelTags.forEach(function (labelTag) {
+      labelTags.forEach((labelTag) => {
         if (inputTag.id && inputTag.id === labelTag.forValue) {
           found = true
         }

--- a/src/rules/script-disabled.js
+++ b/src/rules/script-disabled.js
@@ -1,18 +1,14 @@
 export default {
   id: 'script-disabled',
   description: 'The <script> tag cannot be used.',
-  init: function (parser, reporter) {
-    'use strict'
-
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'script') {
         reporter.error(
           'The <script> tag cannot be used.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/script-disabled.js
+++ b/src/rules/script-disabled.js
@@ -6,7 +6,7 @@ export default {
 
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'script') {
         reporter.error(
           'The <script> tag cannot be used.',

--- a/src/rules/space-tab-mixed-disabled.js
+++ b/src/rules/space-tab-mixed-disabled.js
@@ -1,8 +1,7 @@
 export default {
   id: 'space-tab-mixed-disabled',
   description: 'Do not mix tabs and spaces for indentation.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var indentMode = 'nomix'
     var spaceLengthRequire = null
 
@@ -36,7 +35,7 @@ export default {
                   ' length.',
                 fixedPos.line,
                 1,
-                self,
+                this,
                 event.raw
               )
             }
@@ -46,7 +45,7 @@ export default {
                 'Please use space for indentation.',
                 fixedPos.line,
                 1,
-                self,
+                this,
                 event.raw
               )
             }
@@ -56,7 +55,7 @@ export default {
             'Please use tab for indentation.',
             fixedPos.line,
             1,
-            self,
+            this,
             event.raw
           )
         } else if (/ +\t|\t+ /.test(whiteSpace) === true) {
@@ -64,7 +63,7 @@ export default {
             'Do not mix tabs and spaces for indentation.',
             fixedPos.line,
             1,
-            self,
+            this,
             event.raw
           )
         }

--- a/src/rules/space-tab-mixed-disabled.js
+++ b/src/rules/space-tab-mixed-disabled.js
@@ -12,7 +12,7 @@ export default {
       spaceLengthRequire = match[2] && parseInt(match[2], 10)
     }
 
-    parser.addListener('text', function (event) {
+    parser.addListener('text', (event) => {
       var raw = event.raw
       var reMixed = /(^|\r?\n)([ \t]+)/g
       var match

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -5,7 +5,7 @@ export default {
     parser.addListener('text', (event) => {
       var raw = event.raw
       // TODO: improve use-cases for &
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-useless-escape
       var reSpecChar = /([<>])|( \& )/g
       var match
 

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -1,9 +1,7 @@
 export default {
   id: 'spec-char-escape',
   description: 'Special characters must be escaped.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('text', (event) => {
       var raw = event.raw
       // TODO: improve use-cases for &
@@ -17,7 +15,7 @@ export default {
           'Special characters must be escaped : [ ' + match[0] + ' ].',
           fixedPos.line,
           fixedPos.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('text', function (event) {
+    parser.addListener('text', (event) => {
       var raw = event.raw
       // TODO: improve use-cases for &
       // eslint-disable-next-line

--- a/src/rules/src-not-empty.js
+++ b/src/rules/src-not-empty.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var tagName = event.tagName
       var attrs = event.attrs
       var attr

--- a/src/rules/src-not-empty.js
+++ b/src/rules/src-not-empty.js
@@ -1,9 +1,7 @@
 export default {
   id: 'src-not-empty',
   description: 'The src attribute of an img(script,link) must have a value.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       var tagName = event.tagName
       var attrs = event.attrs
@@ -28,7 +26,7 @@ export default {
               ' ] must have a value.',
             event.line,
             col + attr.index,
-            self,
+            this,
             attr.raw
           )
         }

--- a/src/rules/style-disabled.js
+++ b/src/rules/style-disabled.js
@@ -1,16 +1,14 @@
 export default {
   id: 'style-disabled',
   description: '<style> tags cannot be used.',
-  init: function (parser, reporter) {
-    var self = this
-
+  init(parser, reporter) {
     parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'style') {
         reporter.warn(
           'The <style> tag cannot be used.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/style-disabled.js
+++ b/src/rules/style-disabled.js
@@ -4,7 +4,7 @@ export default {
   init: function (parser, reporter) {
     var self = this
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'style') {
         reporter.warn(
           'The <style> tag cannot be used.',

--- a/src/rules/tag-pair.js
+++ b/src/rules/tag-pair.js
@@ -1,8 +1,7 @@
 export default {
   id: 'tag-pair',
   description: 'Tag must be paired.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var stack = []
     var mapEmptyTags = parser.makeMap(
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
@@ -47,7 +46,7 @@ export default {
               '.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         }
@@ -57,7 +56,7 @@ export default {
           'Tag must be paired, no start tag: [ ' + event.raw + ' ]',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }
@@ -82,7 +81,7 @@ export default {
             '.',
           event.line,
           event.col,
-          self,
+          this,
           ''
         )
       }

--- a/src/rules/tag-pair.js
+++ b/src/rules/tag-pair.js
@@ -8,7 +8,7 @@ export default {
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
     ) //HTML 4.01 + HTML 5
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var tagName = event.tagName.toLowerCase()
       if (mapEmptyTags[tagName] === undefined && !event.close) {
         stack.push({
@@ -19,7 +19,7 @@ export default {
       }
     })
 
-    parser.addListener('tagend', function (event) {
+    parser.addListener('tagend', (event) => {
       var tagName = event.tagName.toLowerCase()
 
       // Look up the matching start tag
@@ -63,7 +63,7 @@ export default {
       }
     })
 
-    parser.addListener('end', function (event) {
+    parser.addListener('end', (event) => {
       var arrTags = []
 
       for (var i = stack.length - 1; i >= 0; i--) {

--- a/src/rules/tag-self-close.js
+++ b/src/rules/tag-self-close.js
@@ -1,8 +1,7 @@
 export default {
   id: 'tag-self-close',
   description: 'Empty tags must be self closed.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var mapEmptyTags = parser.makeMap(
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
     ) //HTML 4.01 + HTML 5
@@ -15,7 +14,7 @@ export default {
             'The empty tag : [ ' + tagName + ' ] must be self closed.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         }

--- a/src/rules/tag-self-close.js
+++ b/src/rules/tag-self-close.js
@@ -7,7 +7,7 @@ export default {
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
     ) //HTML 4.01 + HTML 5
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var tagName = event.tagName.toLowerCase()
       if (mapEmptyTags[tagName] !== undefined) {
         if (!event.close) {

--- a/src/rules/tagname-lowercase.js
+++ b/src/rules/tagname-lowercase.js
@@ -1,8 +1,7 @@
 export default {
   id: 'tagname-lowercase',
   description: 'All html element names must be in lowercase.',
-  init: function (parser, reporter, options) {
-    var self = this
+  init(parser, reporter, options) {
     var exceptions = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart,tagend', (event) => {
@@ -15,7 +14,7 @@ export default {
           'The html element name of [ ' + tagName + ' ] must be in lowercase.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/tagname-lowercase.js
+++ b/src/rules/tagname-lowercase.js
@@ -5,7 +5,7 @@ export default {
     var self = this
     var exceptions = Array.isArray(options) ? options : []
 
-    parser.addListener('tagstart,tagend', function (event) {
+    parser.addListener('tagstart,tagend', (event) => {
       var tagName = event.tagName
       if (
         exceptions.indexOf(tagName) === -1 &&

--- a/src/rules/tagname-specialchars.js
+++ b/src/rules/tagname-specialchars.js
@@ -1,8 +1,7 @@
 export default {
   id: 'tagname-specialchars',
   description: 'All html element names must be in lowercase.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var specialchars = /[^a-zA-Z0-9\-:_]/
 
     parser.addListener('tagstart,tagend', (event) => {
@@ -14,7 +13,7 @@ export default {
             ' ] contains special character.',
           event.line,
           event.col,
-          self,
+          this,
           event.raw
         )
       }

--- a/src/rules/tagname-specialchars.js
+++ b/src/rules/tagname-specialchars.js
@@ -5,7 +5,7 @@ export default {
     var self = this
     var specialchars = /[^a-zA-Z0-9\-:_]/
 
-    parser.addListener('tagstart,tagend', function (event) {
+    parser.addListener('tagstart,tagend', (event) => {
       var tagName = event.tagName
       if (specialchars.test(tagName)) {
         reporter.error(

--- a/src/rules/tags-check.js
+++ b/src/rules/tags-check.js
@@ -50,7 +50,7 @@ export default {
       assign(tagsTypings, options)
     }
 
-    parser.addListener('tagstart', function (event) {
+    parser.addListener('tagstart', (event) => {
       var attrs = event.attrs
       var col = event.col + event.tagName.length + 1
 
@@ -78,20 +78,20 @@ export default {
         }
 
         if (currentTagType.attrsRequired) {
-          currentTagType.attrsRequired.forEach(function (id) {
+          currentTagType.attrsRequired.forEach((id) => {
             if (Array.isArray(id)) {
-              var copyOfId = id.map(function (a) {
+              var copyOfId = id.map((a) => {
                 return a
               })
               var realID = copyOfId.shift()
               var values = copyOfId
 
               if (
-                attrs.some(function (attr) {
+                attrs.some((attr) => {
                   return attr.name === realID
                 })
               ) {
-                attrs.forEach(function (attr) {
+                attrs.forEach((attr) => {
                   if (
                     attr.name === realID &&
                     values.indexOf(attr.value) === -1
@@ -121,7 +121,7 @@ export default {
                 )
               }
             } else if (
-              !attrs.some(function (attr) {
+              !attrs.some((attr) => {
                 return id.split('|').indexOf(attr.name) !== -1
               })
             ) {
@@ -137,20 +137,20 @@ export default {
         }
 
         if (currentTagType.attrsOptional) {
-          currentTagType.attrsOptional.forEach(function (id) {
+          currentTagType.attrsOptional.forEach((id) => {
             if (Array.isArray(id)) {
-              var copyOfId = id.map(function (a) {
+              var copyOfId = id.map((a) => {
                 return a
               })
               var realID = copyOfId.shift()
               var values = copyOfId
 
               if (
-                attrs.some(function (attr) {
+                attrs.some((attr) => {
                   return attr.name === realID
                 })
               ) {
-                attrs.forEach(function (attr) {
+                attrs.forEach((attr) => {
                   if (
                     attr.name === realID &&
                     values.indexOf(attr.value) === -1
@@ -176,9 +176,9 @@ export default {
         }
 
         if (currentTagType.redundantAttrs) {
-          currentTagType.redundantAttrs.forEach(function (attrName) {
+          currentTagType.redundantAttrs.forEach((attrName) => {
             if (
-              attrs.some(function (attr) {
+              attrs.some((attr) => {
                 return attr.name === attrName
               })
             ) {

--- a/src/rules/tags-check.js
+++ b/src/rules/tags-check.js
@@ -43,9 +43,7 @@ var assign = function (target) {
 export default {
   id: 'tags-check',
   description: 'Checks html tags.',
-  init: function (parser, reporter, options) {
-    var self = this
-
+  init(parser, reporter, options) {
     if (typeof options !== 'boolean') {
       assign(tagsTypings, options)
     }
@@ -64,7 +62,7 @@ export default {
             'The <' + tagName + '> tag must be selfclosing.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         } else if (currentTagType.selfclosing === false && event.close) {
@@ -72,7 +70,7 @@ export default {
             'The <' + tagName + '> tag must not be selfclosing.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         }
@@ -100,7 +98,7 @@ export default {
                         "'.",
                       event.line,
                       col,
-                      self,
+                      this,
                       event.raw
                     )
                   }
@@ -110,7 +108,7 @@ export default {
                   'The <' + tagName + "> tag must have attr '" + realID + "'.",
                   event.line,
                   col,
-                  self,
+                  this,
                   event.raw
                 )
               }
@@ -121,7 +119,7 @@ export default {
                 'The <' + tagName + "> tag must have attr '" + id + "'.",
                 event.line,
                 col,
-                self,
+                this,
                 event.raw
               )
             }
@@ -151,7 +149,7 @@ export default {
                         "'.",
                       event.line,
                       col,
-                      self,
+                      this,
                       event.raw
                     )
                   }
@@ -172,7 +170,7 @@ export default {
                   '> and should be ommited.',
                 event.line,
                 col,
-                self,
+                this,
                 event.raw
               )
             }

--- a/src/rules/tags-check.js
+++ b/src/rules/tags-check.js
@@ -80,17 +80,11 @@ export default {
         if (currentTagType.attrsRequired) {
           currentTagType.attrsRequired.forEach((id) => {
             if (Array.isArray(id)) {
-              var copyOfId = id.map((a) => {
-                return a
-              })
+              var copyOfId = id.map((a) => a)
               var realID = copyOfId.shift()
               var values = copyOfId
 
-              if (
-                attrs.some((attr) => {
-                  return attr.name === realID
-                })
-              ) {
+              if (attrs.some((attr) => attr.name === realID)) {
                 attrs.forEach((attr) => {
                   if (
                     attr.name === realID &&
@@ -121,9 +115,7 @@ export default {
                 )
               }
             } else if (
-              !attrs.some((attr) => {
-                return id.split('|').indexOf(attr.name) !== -1
-              })
+              !attrs.some((attr) => id.split('|').indexOf(attr.name) !== -1)
             ) {
               reporter.error(
                 'The <' + tagName + "> tag must have attr '" + id + "'.",
@@ -139,17 +131,11 @@ export default {
         if (currentTagType.attrsOptional) {
           currentTagType.attrsOptional.forEach((id) => {
             if (Array.isArray(id)) {
-              var copyOfId = id.map((a) => {
-                return a
-              })
+              var copyOfId = id.map((a) => a)
               var realID = copyOfId.shift()
               var values = copyOfId
 
-              if (
-                attrs.some((attr) => {
-                  return attr.name === realID
-                })
-              ) {
+              if (attrs.some((attr) => attr.name === realID)) {
                 attrs.forEach((attr) => {
                   if (
                     attr.name === realID &&
@@ -177,11 +163,7 @@ export default {
 
         if (currentTagType.redundantAttrs) {
           currentTagType.redundantAttrs.forEach((attrName) => {
-            if (
-              attrs.some((attr) => {
-                return attr.name === attrName
-              })
-            ) {
+            if (attrs.some((attr) => attr.name === attrName)) {
               reporter.error(
                 "The attr '" +
                   attrName +

--- a/src/rules/title-require.js
+++ b/src/rules/title-require.js
@@ -5,7 +5,7 @@ export default {
     var headBegin = false
     var hasTitle = false
 
-    function onTagStart(event) {
+    var onTagStart = (event) => {
       var tagName = event.tagName.toLowerCase()
       if (tagName === 'head') {
         headBegin = true
@@ -14,7 +14,7 @@ export default {
       }
     }
 
-    function onTagEnd(event) {
+    var onTagEnd = (event) => {
       var tagName = event.tagName.toLowerCase()
       if (hasTitle && tagName === 'title') {
         var lastEvent = event.lastEvent

--- a/src/rules/title-require.js
+++ b/src/rules/title-require.js
@@ -1,8 +1,7 @@
 export default {
   id: 'title-require',
   description: '<title> must be present in <head> tag.',
-  init: function (parser, reporter) {
-    var self = this
+  init(parser, reporter) {
     var headBegin = false
     var hasTitle = false
 
@@ -27,7 +26,7 @@ export default {
             '<title></title> must not be empty.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         }
@@ -37,7 +36,7 @@ export default {
             '<title> must be present in <head> tag.',
             event.line,
             event.col,
-            self,
+            this,
             event.raw
           )
         }

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -2,28 +2,28 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../dist/htmlhint.js').HTMLHint
 
-describe('Core', function () {
-  it('Set false to rule no effected should result in an error', function () {
+describe('Core', () => {
+  it('Set false to rule no effected should result in an error', () => {
     const code = '<img src="test.gif" />'
     const messages = HTMLHint.verify(code, { 'alt-require': false })
     expect(messages.length).to.be(0)
   })
 
-  it('Not load default ruleset when use undefined ruleset should result in an error', function () {
+  it('Not load default ruleset when use undefined ruleset should result in an error', () => {
     const code =
       '<P ATTR=\'1\' id="a">><div id="a"><img src="" a="1" a="2"/></div>'
     const messages = HTMLHint.verify(code)
     expect(messages.length).to.be(9)
   })
 
-  it('Not load default ruleset when use empty ruleset should result in an error', function () {
+  it('Not load default ruleset when use empty ruleset should result in an error', () => {
     const code =
       '<P ATTR=\'1\' id="a">><div id="a"><img src="" a="1" a="2"/></div>'
     const messages = HTMLHint.verify(code, {})
     expect(messages.length).to.be(9)
   })
 
-  it('Inline ruleset not worked should result in an error', function () {
+  it('Inline ruleset not worked should result in an error', () => {
     let code = '<!-- htmlhint alt-require:true-->\r\n<img src="test.gif" />'
     let messages = HTMLHint.verify(code, {
       'alt-require': false,
@@ -41,7 +41,7 @@ describe('Core', function () {
     expect(messages.length).to.be(0)
   })
 
-  it('Show formated result should not result in an error', function () {
+  it('Show formated result should not result in an error', () => {
     const code =
       'tttttttttttttttttttttttttttttttttttt<div>中文<img src="test.gif" />tttttttttttttttttttttttttttttttttttttttttttttt'
     const messages = HTMLHint.verify(code, {

--- a/test/executable.spec.js
+++ b/test/executable.spec.js
@@ -3,8 +3,8 @@ const expect = require('expect.js')
 const ChildProcess = require('child_process')
 const path = require('path')
 
-describe('Executable', function () {
-  it('should close stream before exit', function (done) {
+describe('Executable', () => {
+  it('should close stream before exit', (done) => {
     const c = ChildProcess.spawn('node', [
       path.resolve(__dirname, '../bin/htmlhint'),
       '--format',

--- a/test/htmlparser.spec.js
+++ b/test/htmlparser.spec.js
@@ -3,8 +3,7 @@ const expect = require('expect.js')
 const HTMLParser = require('../dist/htmlhint.js').HTMLParser
 
 expect.Assertion.prototype.event = function (type, attr) {
-  const self = this
-  const obj = self.obj
+  const obj = this.obj
 
   if (attr !== undefined) {
     attr.type = type
@@ -15,7 +14,7 @@ expect.Assertion.prototype.event = function (type, attr) {
       attr = type
     }
   }
-  self.assert(
+  this.assert(
     eqlEvent(obj, attr),
     () =>
       `expected "${JSON.stringify(obj)}" to event "${JSON.stringify(attr)}"`,

--- a/test/htmlparser.spec.js
+++ b/test/htmlparser.spec.js
@@ -42,8 +42,8 @@ function getAllEvents(parser, arrEvents, callback) {
   })
 }
 
-describe('HTMLParser: Base parse', function () {
-  it('should parse html code1', function (done) {
+describe('HTMLParser: Base parse', () => {
+  it('should parse html code1', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     const targetEvents = [
@@ -234,8 +234,8 @@ describe('HTMLParser: Base parse', function () {
   })
 })
 
-describe('HTMLParser: Object parse', function () {
-  it('should parse doctype: HTML Strict DTD', function (done) {
+describe('HTMLParser: Object parse', () => {
+  it('should parse doctype: HTML Strict DTD', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -251,7 +251,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: HTML Transitional DTD', function (done) {
+  it('should parse doctype: HTML Transitional DTD', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -267,7 +267,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: HTML Frameset DTD', function (done) {
+  it('should parse doctype: HTML Frameset DTD', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -283,7 +283,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: XHTML 1.0 Strict', function (done) {
+  it('should parse doctype: XHTML 1.0 Strict', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -299,7 +299,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: XHTML 1.0 Transitional', function (done) {
+  it('should parse doctype: XHTML 1.0 Transitional', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -315,7 +315,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: XHTML 1.0 Frameset', function (done) {
+  it('should parse doctype: XHTML 1.0 Frameset', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -331,7 +331,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: XHTML 1.1', function (done) {
+  it('should parse doctype: XHTML 1.1', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -347,7 +347,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse doctype: html5', function (done) {
+  it('should parse doctype: html5', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -360,7 +360,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<!DOCTYPE HTML>')
   })
 
-  it('should parse start tag: <p>', function (done) {
+  it('should parse start tag: <p>', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -372,7 +372,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<p>')
   })
 
-  it('should not parse start tag: <div class"foo">', function (done) {
+  it('should not parse start tag: <div class"foo">', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -384,7 +384,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class"foo">')
   })
 
-  it('should not parse start tag: <div class="foo>', function (done) {
+  it('should not parse start tag: <div class="foo>', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -396,7 +396,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class="foo>')
   })
 
-  it('should not parse start tag: <div class=foo">', function (done) {
+  it('should not parse start tag: <div class=foo">', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -408,7 +408,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class=foo">')
   })
 
-  it('should not parse start tag: <div class="foo"">', function (done) {
+  it('should not parse start tag: <div class="foo"">', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -420,7 +420,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class="foo"">')
   })
 
-  it('should not parse start tag: <div class="foo""><span">', function (done) {
+  it('should not parse start tag: <div class="foo""><span">', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -432,7 +432,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class="foo""><span">')
   })
 
-  it('should not parse start tag: <div class="foo""><a><span">', function (done) {
+  it('should not parse start tag: <div class="foo""><a><span">', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -444,7 +444,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<div class="foo""><a><span">')
   })
 
-  it('should parse tag attrs', function (done) {
+  it('should parse tag attrs', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -476,7 +476,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<img width="200" height=\'300\' alt=abc a.b=ccc c*d=ddd>')
   })
 
-  it('should parse end tag', function (done) {
+  it('should parse end tag', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -488,7 +488,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('</p>')
   })
 
-  it('should parse selfclose tag', function (done) {
+  it('should parse selfclose tag', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -501,7 +501,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<br />')
   })
 
-  it('should parse text', function (done) {
+  it('should parse text', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -513,7 +513,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<span>abc</span>')
   })
 
-  it('should parse text in last', function (done) {
+  it('should parse text in last', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -525,7 +525,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<p>bbb')
   })
 
-  it('should parse comment', function (done) {
+  it('should parse comment', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -538,7 +538,7 @@ describe('HTMLParser: Object parse', function () {
     parser.parse('<!--comment\r\ntest-->')
   })
 
-  it('should parse cdata: script', function (done) {
+  it('should parse cdata: script', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -564,7 +564,7 @@ describe('HTMLParser: Object parse', function () {
     )
   })
 
-  it('should parse cdata: style', function (done) {
+  it('should parse cdata: style', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -588,7 +588,7 @@ describe('HTMLParser: Object parse', function () {
 })
 
 describe('HTMLParser: Case parse', () => {
-  it('should parse special end tag', function (done) {
+  it('should parse special end tag', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -600,7 +600,7 @@ describe('HTMLParser: Case parse', () => {
     parser.parse('</p >')
   })
 
-  it('should parse special no quotes tags', function (done) {
+  it('should parse special no quotes tags', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {
@@ -615,7 +615,7 @@ describe('HTMLParser: Case parse', () => {
     parser.parse('<link rel=icon /><link rel=icon />')
   })
 
-  it('should parse special empty attr', function (done) {
+  it('should parse special empty attr', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []
     getAllEvents(parser, arrEvents, () => {

--- a/test/rules/alt-require.spec.js
+++ b/test/rules/alt-require.spec.js
@@ -7,20 +7,20 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Img tag have empty alt attribute should not result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Img tag have empty alt attribute should not result in an error', () => {
     const code = '<img width="200" height="300" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Img tag have non empty alt attribute should not result in an error', function () {
+  it('Img tag have non empty alt attribute should not result in an error', () => {
     const code = '<img width="200" height="300" alt="test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Img tag have not alt attribute should result in an error', function () {
+  it('Img tag have not alt attribute should result in an error', () => {
     const code = '<img width="200" height="300">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -31,19 +31,19 @@ describe(`Rules: ${ruldId}`, function () {
   })
 
   /* A tag can have shape and coords attributes and not have alt attribute */
-  it('A tag have not alt attribute should not result in an error', function () {
+  it('A tag have not alt attribute should not result in an error', () => {
     const code = '<a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Area tag have not href and alt attributes should not result in an error', function () {
+  it('Area tag have not href and alt attributes should not result in an error', () => {
     const code = '<area>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Area[href] tag have not alt attribute should result in an error', function () {
+  it('Area[href] tag have not alt attribute should result in an error', () => {
     const code = '<area href="#test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -53,7 +53,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Area[href] tag have empty alt attribute should result in an error', function () {
+  it('Area[href] tag have empty alt attribute should result in an error', () => {
     const code = '<area href="#test" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -63,25 +63,25 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Area[href] tag have non emtpy alt attribute should not result in an error', function () {
+  it('Area[href] tag have non emtpy alt attribute should not result in an error', () => {
     const code = '<area href="#test" alt="test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Input tag have not type and alt attributes should not result in an error', function () {
+  it('Input tag have not type and alt attributes should not result in an error', () => {
     const code = '<input>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Input[type="text"] tag have not alt attribute should not result in an error', function () {
+  it('Input[type="text"] tag have not alt attribute should not result in an error', () => {
     const code = '<input type="text">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Input[type="image"] tag have not alt attribute should result in an error', function () {
+  it('Input[type="image"] tag have not alt attribute should result in an error', () => {
     const code = '<input type="image">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -91,7 +91,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Input[type="image"] tag have empty alt attribute should result in an error', function () {
+  it('Input[type="image"] tag have empty alt attribute should result in an error', () => {
     const code = '<input type="image" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -101,7 +101,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Input[type="image"] tag have non emtpy alt attribute should not result in an error', function () {
+  it('Input[type="image"] tag have non emtpy alt attribute should not result in an error', () => {
     const code = '<input type="image" alt="test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Not all lowercase attr should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Not all lowercase attr should result in an error', () => {
     let code = '<p TEST="abc">'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -27,34 +27,34 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].col).to.be(13)
   })
 
-  it('Lowercase attr should not result in an error', function () {
+  it('Lowercase attr should not result in an error', () => {
     const code = '<p test="abc">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Set is false should not result in an error', function () {
+  it('Set is false should not result in an error', () => {
     const code = '<p TEST="abc">'
     ruleOptions[ruldId] = false
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Set to array list should not result in an error', function () {
+  it('Set to array list should not result in an error', () => {
     const code = '<p testBox="abc" tttAAA="ccc">'
     ruleOptions[ruldId] = ['testBox', 'tttAAA']
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Set to array list with RegExp should not result in an error', function () {
+  it('Set to array list with RegExp should not result in an error', () => {
     const code = '<p testBox="abc" bind:tapTop="ccc">'
     ruleOptions[ruldId] = ['testBox', /bind:.*/]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Set to array list with regex string should not result in an error', function () {
+  it('Set to array list with regex string should not result in an error', () => {
     const code = '<p testBox="abc" [ngFor]="ccc">'
     ruleOptions[ruldId] = ['testBox', '/\\[.*\\]/']
     const messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/attr-no-duplication.spec.js
+++ b/test/rules/attr-no-duplication.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Attribute name been duplication should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Attribute name been duplication should result in an error', () => {
     const code = '<a href="a" href="b">bbb</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -17,7 +17,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(12)
   })
 
-  it('Attribute name not been duplication should not result in an error', function () {
+  it('Attribute name not been duplication should not result in an error', () => {
     const code = '<a href="a">bbb</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -7,8 +7,8 @@ var ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
-  it('Attribute with spaces should result in an error', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Attribute with spaces should result in an error', () => {
     var codes = [
       '<div title = "a" />',
       '<div title= "a" />',
@@ -23,7 +23,7 @@ describe('Rules: ' + ruldId, function () {
     }
   })
 
-  it('Attribute without spaces should not result in an error', function () {
+  it('Attribute without spaces should not result in an error', () => {
     var codes = ['<div title="a" />', '<div title="a = a" />']
     for (var i = 0; i < codes.length; i++) {
       var messages = HTMLHint.verify(codes[i], ruleOptions)

--- a/test/rules/attr-sort.spec.js
+++ b/test/rules/attr-sort.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruleId}`, function () {
-  it('Attribute unsorted tags must result in an error', function () {
+describe(`Rules: ${ruleId}`, () => {
+  it('Attribute unsorted tags must result in an error', () => {
     const code = '<div id="test" class="class" title="tite"></div>'
 
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruleId}`, function () {
     expect(messages[0].message).to.contain('["id","class","title"]')
   })
 
-  it('Attribute unsorted tags that are unrecognizable should not throw error', function () {
+  it('Attribute unsorted tags that are unrecognizable should not throw error', () => {
     const code = '<div img="image" meta="meta" font="font"></div>'
 
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -26,7 +26,7 @@ describe(`Rules: ${ruleId}`, function () {
     expect(messages.length).to.be(0)
   })
 
-  it('Attribute unsorted of tags of various types should throw error', function () {
+  it('Attribute unsorted of tags of various types should throw error', () => {
     const code = '<div type="type" img="image" id="id" font="font"></div>'
 
     const messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/attr-unsafe-chars.spec.js
+++ b/test/rules/attr-unsafe-chars.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Attribute value have unsafe chars should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Attribute value have unsafe chars should result in an error', () => {
     const code =
       '<a href="https://vimeo.com/album/1951235/video/56931059‎">Sud Web 2012</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -19,13 +19,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Attribute value have no unsafe chars should not result in an error', function () {
+  it('Attribute value have no unsafe chars should not result in an error', () => {
     const code = '<input disabled="disabled" />'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Attribute value have \\r\\n\\t should not result in an error', function () {
+  it('Attribute value have \\r\\n\\t should not result in an error', () => {
     const code =
       '<link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,R0lGODlhEAAQAKEAAAAAAICAgP///wAAACH/\nC05FVFNDQVBFMi4wAwEAAAAh/hFDcmVhdGVkIHdpdGggR0lNUAAh+QQBZAADACwAAAAAEAAQAAACJIyPacLtvp5kEUwYmL00i81VXK\neNgjiioQdeqsuakXl6tIIjBQAh+QQBZAADACwAAAAAEAAQAAACIIyPacLtvp5kcb5qG85iZ2+BkyiRV8BBaEqtrKkqslEAADs=\t"/>'
     const messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/attr-value-double-quotes.spec.js
+++ b/test/rules/attr-value-double-quotes.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Attribute value closed by single quotes should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Attribute value closed by single quotes should result in an error', () => {
     const code = "<a href='abc' title=abc style=''>"
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
@@ -23,7 +23,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[2].col).to.be(24)
   })
 
-  it('Attribute value no closed should not result in an error', function () {
+  it('Attribute value no closed should not result in an error', () => {
     const code = '<input type="button" disabled style="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-value-not-empty.spec.js
+++ b/test/rules/attr-value-not-empty.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Attribute value have no value should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Attribute value have no value should result in an error', () => {
     const code = '<input disabled>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -18,13 +18,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Attribute value closed by quote but no value should not result in an error', function () {
+  it('Attribute value closed by quote but no value should not result in an error', () => {
     const code = '<input disabled="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Attribute value closed by quote and have value should not result in an error', function () {
+  it('Attribute value closed by quote and have value should not result in an error', () => {
     const code = '<input disabled="disabled">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-value-single-quotes.spec.js
+++ b/test/rules/attr-value-single-quotes.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
-  it('Attribute value closed by double quotes should result in an error', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Attribute value closed by double quotes should result in an error', () => {
     var code = '<a href="abc" title=abc style="">'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
@@ -23,7 +23,7 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[2].col).to.be(24)
   })
 
-  it('Attribute value no closed should not result in an error', function () {
+  it('Attribute value no closed should not result in an error', () => {
     var code = "<input type='button' disabled style=''>"
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-whitespace.spec.js
+++ b/test/rules/attr-whitespace.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Double spaces in attributes should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Double spaces in attributes should result in an error', () => {
     let code = '<p test="test  test1">'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -16,7 +16,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].line).to.be(1)
   })
 
-  it('Leading/trailing white space should result in an error', function () {
+  it('Leading/trailing white space should result in an error', () => {
     let code = '<p test=" testtest1 ">'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -24,7 +24,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].line).to.be(1)
   })
 
-  it('Double spaces and leading/trailing white space should result in an error', function () {
+  it('Double spaces and leading/trailing white space should result in an error', () => {
     let code = '<p test=" test  test1 ">'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)

--- a/test/rules/default.spec.js
+++ b/test/rules/default.spec.js
@@ -2,8 +2,8 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-describe('Rules: default', function () {
-  it('should result 3 errors', function () {
+describe('Rules: default', () => {
+  it('should result 3 errors', () => {
     const code = '<p TEST="abc">'
     const messages = HTMLHint.verify(code)
     expect(messages.length).to.be(3)

--- a/test/rules/doctype-first.spec.js
+++ b/test/rules/doctype-first.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Doctype not be first should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Doctype not be first should result in an error', () => {
     const code = '<html></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -17,7 +17,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(1)
   })
 
-  it('Doctype be first should not result in an error', function () {
+  it('Doctype be first should not result in an error', () => {
     const code = '<!DOCTYPE HTML><html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/doctype-html5.spec.js
+++ b/test/rules/doctype-html5.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Doctype not html5 should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Doctype not html5 should result in an error', () => {
     const code =
       '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd"><html></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -19,7 +19,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Doctype html5 should not result in an error', function () {
+  it('Doctype html5 should not result in an error', () => {
     const code = '<!DOCTYPE HTML><html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('External script in head should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Internal Script in head should result in an error', function () {
+  it('Internal Script in head should result in an error', () => {
     let code = '<head><script>alert(1);</script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -34,13 +34,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(1)
   })
 
-  it('Script in body not result in an error', function () {
+  it('Script in body not result in an error', () => {
     const code = '<head></head><body><script src="test.js"></script></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Template script in head not result in an error', function () {
+  it('Template script in head not result in an error', () => {
     let code =
       '<head><script type="text/template"><img src="test.png" /></script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
@@ -51,7 +51,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(0)
   })
 
-  it('No head not result in an error', function () {
+  it('No head not result in an error', () => {
     const code = '<html><script src="test.js"></script></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/head-script-disabled.spec.js
+++ b/test/rules/head-script-disabled.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('External script in head should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Internal Script in head should result in an error', function () {
+  it('Internal Script in head should result in an error', () => {
     let code = '<head><script>alert(1);</script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -34,13 +34,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(1)
   })
 
-  it('Script in body not result in an error', function () {
+  it('Script in body not result in an error', () => {
     const code = '<head></head><body><script src="test.js"></script></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Template script in head not result in an error', function () {
+  it('Template script in head not result in an error', () => {
     let code =
       '<head><script type="text/template"><img src="test.png" /></script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
@@ -51,7 +51,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(0)
   })
 
-  it('No head not result in an error', function () {
+  it('No head not result in an error', () => {
     const code = '<html><script src="test.js"></script></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/href-abs-or-rel.spec.js
+++ b/test/rules/href-abs-or-rel.spec.js
@@ -5,8 +5,8 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'href-abs-or-rel'
 const ruleOptions = {}
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Href value is not absolute with abs mode should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Href value is not absolute with abs mode should result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = 'abs'
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].col).to.be(27)
   })
 
-  it('Href value is absolute with abs mode should not result in an error', function () {
+  it('Href value is absolute with abs mode should not result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = 'abs'
@@ -28,7 +28,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(0)
   })
 
-  it('Href value is not relative with rel mode should result in an error', function () {
+  it('Href value is not relative with rel mode should result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = 'rel'
@@ -42,7 +42,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].col).to.be(44)
   })
 
-  it('Href value is relative with rel mode should not result in an error', function () {
+  it('Href value is relative with rel mode should not result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = 'rel'

--- a/test/rules/id-class-ad-disabled.spec.js
+++ b/test/rules/id-class-ad-disabled.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Id use ad keyword should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Id use ad keyword should result in an error', () => {
     let code = '<div id="ad">test</div>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -60,7 +60,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(5)
   })
 
-  it('Class use ad keyword should result in an error', function () {
+  it('Class use ad keyword should result in an error', () => {
     let code = '<div class="ad">test</div>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -111,7 +111,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(5)
   })
 
-  it('Id and class no ad keyword used should not result in an error', function () {
+  it('Id and class no ad keyword used should not result in an error', () => {
     let code = '<div id="ad1" class="ad2">test</div>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -16,8 +16,8 @@ ruleOptionsReg[ruldId] = {
   message: 'Id and class value must meet regexp',
 }
 
-describe('Rules: ' + ruldId, function () {
-  it('Id and class value be not lower case and split by underline should result in an error', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Id and class value be not lower case and split by underline should result in an error', () => {
     var code = '<div id="aaaBBB" class="ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsUnderline)
     expect(messages.length).to.be(2)
@@ -31,13 +31,13 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[1].type).to.be('warning')
   })
 
-  it('Id and class value be lower case and split by underline should not result in an error', function () {
+  it('Id and class value be lower case and split by underline should not result in an error', () => {
     var code = '<div id="aaa_bbb" class="ccc_ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsUnderline)
     expect(messages.length).to.be(0)
   })
 
-  it('Id and class value be not lower case and split by dash should result in an error', function () {
+  it('Id and class value be not lower case and split by dash should result in an error', () => {
     var code = '<div id="aaaBBB" class="ccc_ddd">'
     var messages = HTMLHint.verify(code, { 'id-class-value': 'dash' })
     expect(messages.length).to.be(2)
@@ -49,13 +49,13 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[1].col).to.be(17)
   })
 
-  it('Id and class value be lower case and split by dash should not result in an error', function () {
+  it('Id and class value be lower case and split by dash should not result in an error', () => {
     var code = '<div id="aaa-bbb" class="ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsDash)
     expect(messages.length).to.be(0)
   })
 
-  it('Id and class value be not meet hump style should result in an error', function () {
+  it('Id and class value be not meet hump style should result in an error', () => {
     var code = '<div id="aaa_bb" class="ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsHump)
     expect(messages.length).to.be(2)
@@ -67,13 +67,13 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[1].col).to.be(17)
   })
 
-  it('Id and class value be meet hump style should not result in an error', function () {
+  it('Id and class value be meet hump style should not result in an error', () => {
     var code = '<div id="aaaBbb" class="cccDdd">'
     var messages = HTMLHint.verify(code, ruleOptionsHump)
     expect(messages.length).to.be(0)
   })
 
-  it('Id and class value be not meet regexp should result in an error', function () {
+  it('Id and class value be not meet regexp should result in an error', () => {
     var code = '<div id="aa-bb" class="ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsReg)
     expect(messages.length).to.be(2)
@@ -85,7 +85,7 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[1].col).to.be(16)
   })
 
-  it('Id and class value be meet regexp should not result in an error', function () {
+  it('Id and class value be meet regexp should not result in an error', () => {
     var code = '<div id="_aaa-bb" class="_ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsReg)
     expect(messages.length).to.be(0)

--- a/test/rules/id-unique.spec.js
+++ b/test/rules/id-unique.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Id redefine should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Id redefine should result in an error', () => {
     const code = '<div id="test"></div><div id="test"></div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('error')
   })
 
-  it('Id no redefine should not result in an error', function () {
+  it('Id no redefine should not result in an error', () => {
     const code = '<div id="test1"></div><div id="test2"></div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/inline-script-disabled.spec.js
+++ b/test/rules/inline-script-disabled.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Inline on event should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Inline on event should result in an error', () => {
     const code =
       '<body><img src="test.gif" onclick="alert(1);"><img src="test.gif" onMouseDown="alert(1);"></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -20,13 +20,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].col).to.be(66)
   })
 
-  it('onttt should not result in an error', function () {
+  it('onttt should not result in an error', () => {
     const code = '<body><img src="test.gif" onttt="alert(1);"></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Javascript protocol [ javascript: ] should result in an error', function () {
+  it('Javascript protocol [ javascript: ] should result in an error', () => {
     let code =
       '<body><img src="javascript:alert(1)"><img src=" JAVASCRIPT:alert(1)"></body>'
     let messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/inline-style-disabled.spec.js
+++ b/test/rules/inline-style-disabled.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Inline style should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Inline style should result in an error', () => {
     let code = '<body><div style="color:red;"></div></body>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)

--- a/test/rules/input-requires-label.spec.js
+++ b/test/rules/input-requires-label.spec.js
@@ -7,23 +7,23 @@ const ruleOptions = {}
 
 ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruleId}`, function () {
-  describe('Successful cases', function () {
-    it('Input tag with a matching label before should result in no error', function () {
+describe(`Rules: ${ruleId}`, () => {
+  describe('Successful cases', () => {
+    it('Input tag with a matching label before should result in no error', () => {
       var code = '<label for="some-id"/><input id="some-id" type="password" />'
       var messages = HTMLHint.verify(code, ruleOptions)
       expect(messages.length).to.be(0)
     })
 
-    it('Input tag with a matching label after should result in no error', function () {
+    it('Input tag with a matching label after should result in no error', () => {
       var code = '<input id="some-id" type="password" /> <label for="some-id"/>'
       var messages = HTMLHint.verify(code, ruleOptions)
       expect(messages.length).to.be(0)
     })
   })
 
-  describe('Error cases', function () {
-    it('Input tag with no matching label should result in an error', function () {
+  describe('Error cases', () => {
+    it('Input tag with no matching label should result in an error', () => {
       var code = '<input type="password">'
       var messages = HTMLHint.verify(code, ruleOptions)
       expect(messages.length).to.be(1)
@@ -33,7 +33,7 @@ describe(`Rules: ${ruleId}`, function () {
       expect(messages[0].type).to.be('warning')
     })
 
-    it("Input tag with label that doesn't match id should result in error", function () {
+    it("Input tag with label that doesn't match id should result in error", () => {
       var code =
         '<input id="some-id" type="password" /> <label for="some-other-id"/>'
       var messages = HTMLHint.verify(code, ruleOptions)
@@ -44,7 +44,7 @@ describe(`Rules: ${ruleId}`, function () {
       expect(messages[0].type).to.be('warning')
     })
 
-    it('Input tag with blank label:for should result in error', function () {
+    it('Input tag with blank label:for should result in error', () => {
       var code = '<input id="some-id" type="password" /> <label for=""/>'
       var messages = HTMLHint.verify(code, ruleOptions)
       expect(messages.length).to.be(1)
@@ -54,7 +54,7 @@ describe(`Rules: ${ruleId}`, function () {
       expect(messages[0].type).to.be('warning')
     })
 
-    it('Input tag with no id should result in error', function () {
+    it('Input tag with no id should result in error', () => {
       var code = '<input type="password" /> <label for="something"/>'
       var messages = HTMLHint.verify(code, ruleOptions)
       expect(messages.length).to.be(1)

--- a/test/rules/script-disabled.spec.js
+++ b/test/rules/script-disabled.spec.js
@@ -3,8 +3,8 @@ var HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 var ruldId = 'script-disabled'
 var ruleOptions = {}
 ruleOptions[ruldId] = true
-describe('Rules: ' + ruldId, function () {
-  it('Add external script file should result in an error', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Add external script file should result in an error', () => {
     var code = '<body><script src="test.js"></script></body>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -13,7 +13,7 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('error')
   })
-  it('Add inline script should result in an error', function () {
+  it('Add inline script should result in an error', () => {
     var code = '<body><script>var test = "test";</script></body>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -15,8 +15,8 @@ ruleSpace4Options[ruldId] = 'space4'
 ruleSpace5Options[ruldId] = 'space5'
 ruleTabOptions[ruldId] = 'tab'
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Spaces and tabs mixed in front of line should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Spaces and tabs mixed in front of line should result in an error', () => {
     // space before tab
     let code = '    	<a href="a">      bbb</a>'
     let messages = HTMLHint.verify(code, ruleMixOptions)
@@ -40,7 +40,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(1)
   })
 
-  it('Only spaces in front of line should not result in an error', function () {
+  it('Only spaces in front of line should not result in an error', () => {
     let code = '     <a href="a">      bbb</a>'
     let messages = HTMLHint.verify(code, ruleMixOptions)
     expect(messages.length).to.be(0)
@@ -50,13 +50,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(0)
   })
 
-  it('Only tabs in front of line should not result in an error', function () {
+  it('Only tabs in front of line should not result in an error', () => {
     const code = '			<a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleMixOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Not only space in front of line should result in an error', function () {
+  it('Not only space in front of line should result in an error', () => {
     // mixed 1
     let code = '    	<a href="a">      bbb</a>'
     let messages = HTMLHint.verify(code, ruleSpaceOptions)
@@ -73,7 +73,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(1)
   })
 
-  it('Not only space and 4 length in front of line should result in an error', function () {
+  it('Not only space and 4 length in front of line should result in an error', () => {
     const code = '     <a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleSpace4Options)
     expect(messages.length).to.be(1)
@@ -82,13 +82,13 @@ describe(`Rules: ${ruldId}`, function () {
     )
   })
 
-  it('Only space and 4 length in front of line should not result in an error', function () {
+  it('Only space and 4 length in front of line should not result in an error', () => {
     const code = '        <a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleSpace4Options)
     expect(messages.length).to.be(0)
   })
 
-  it('Not only space and 5 length in front of line should result in an error', function () {
+  it('Not only space and 5 length in front of line should result in an error', () => {
     const code = '      <a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleSpace5Options)
     expect(messages.length).to.be(1)
@@ -97,19 +97,19 @@ describe(`Rules: ${ruldId}`, function () {
     )
   })
 
-  it('Only space and 5 length in front of line should not result in an error', function () {
+  it('Only space and 5 length in front of line should not result in an error', () => {
     const code = '          <a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleSpace5Options)
     expect(messages.length).to.be(0)
   })
 
-  it('Only space in front of line should not result in an error', function () {
+  it('Only space in front of line should not result in an error', () => {
     const code = '            <a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleSpaceOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Not only tab in front of line should result in an error', function () {
+  it('Not only tab in front of line should result in an error', () => {
     // mixed 1
     let code = '	    <a href="a">      bbb</a>'
     let messages = HTMLHint.verify(code, ruleTabOptions)
@@ -126,7 +126,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(1)
   })
 
-  it('Only tab in front of line should not result in an error', function () {
+  it('Only tab in front of line should not result in an error', () => {
     // only tab
     const code = '		<a href="a">      bbb</a>'
     const messages = HTMLHint.verify(code, ruleTabOptions)

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -7,8 +7,8 @@ var ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
-  it('Special characters: <> should result in an error', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Special characters: <> should result in an error', () => {
     var code = '<p>aaa>bbb< ccc</p>ddd\r\neee<'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
@@ -23,7 +23,7 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[2].col).to.be(4)
   })
 
-  it('Special characters: & should result in an error', function () {
+  it('Special characters: & should result in an error', () => {
     var code = '<p>Steinway & Sons</p>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -32,13 +32,13 @@ describe('Rules: ' + ruldId, function () {
     expect(messages[0].col).to.be(12)
   })
 
-  it('Normal text should not result in an error', function () {
+  it('Normal text should not result in an error', () => {
     var code = '<p>abc</p>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Properly formed HTML entities should not result in an error', function () {
+  it('Properly formed HTML entities should not result in an error', () => {
     var code = '<p>Steinway &amp; &gt; Sons Q&amp;A </p>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/src-not-empty.spec.js
+++ b/test/rules/src-not-empty.spec.js
@@ -7,22 +7,22 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Src be emtpy should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Src be emtpy should result in an error', () => {
     const code =
       '<img src="" /><img src /><script src=""></script><script src></script><link href="" type="text/css" /><link href type="text/css" /><embed src=""><embed src><bgsound src="" /><bgsound src /><iframe src=""><iframe src><object data=""><object data>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(14)
   })
 
-  it('Src be non-empty should not result in an error', function () {
+  it('Src be non-empty should not result in an error', () => {
     const code =
       '<img src="test.png" /><script src="test.js"></script><link href="test.css" type="text/css" /><embed src="test.swf"><bgsound src="test.mid" /><iframe src="test.html"><object data="test.swf">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('Src be not set value should not result in an error', function () {
+  it('Src be not set value should not result in an error', () => {
     const code =
       '<img width="200" /><script></script><link type="text/css" /><embed width="200"><bgsound /><iframe width="200"><object width="200">'
     const messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/style-disabled.spec.js
+++ b/test/rules/style-disabled.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Style tag should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Style tag should result in an error', () => {
     const code = '<body><style>body{}</style></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Stylesheet link should not result in an error', function () {
+  it('Stylesheet link should not result in an error', () => {
     const code = '<body><link rel="stylesheet" href="test.css" /></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('No end tag should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('No end tag should result in an error', () => {
     let code = '<ul><li></ul><span>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
@@ -26,7 +26,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(9)
   })
 
-  it('No start tag should result in an error', function () {
+  it('No start tag should result in an error', () => {
     const code = '</div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -35,7 +35,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[0].col).to.be(1)
   })
 
-  it('Tag be paired should not result in an error', function () {
+  it('Tag be paired should not result in an error', () => {
     const code = '<p>aaa</p>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/tag-self-close.spec.js
+++ b/test/rules/tag-self-close.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('The empty tag no closed should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('The empty tag no closed should result in an error', () => {
     const code = '<br><img src="test.jpg">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
@@ -23,7 +23,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].type).to.be('warning')
   })
 
-  it('Closed empty tag should not result in an error', function () {
+  it('Closed empty tag should not result in an error', () => {
     const code = '<br /><img src="a.jpg"/>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/tagname-lowercase.spec.js
+++ b/test/rules/tagname-lowercase.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('The tag name not all lower case should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('The tag name not all lower case should result in an error', () => {
     const code = '<A href=""></A><SPAN>aab</spaN>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(4)
@@ -26,7 +26,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[3].col).to.be(25)
   })
 
-  it('All lower case tag name should not result in an error', function () {
+  it('All lower case tag name should not result in an error', () => {
     const code = '<a href=""></a><span>test</span>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/tagname-specialchars.spec.js
+++ b/test/rules/tagname-specialchars.spec.js
@@ -7,8 +7,8 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('Special character in tag name should result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('Special character in tag name should result in an error', () => {
     var code = '<@ href="link"></@><$pan>aab</$pan>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages[1].col).to.be(29)
   })
 
-  it('Tag name without special character should not result in an error', function () {
+  it('Tag name without special character should not result in an error', () => {
     var code = '<a href=""></a><span>test</span>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/tags-check.spec.js
+++ b/test/rules/tags-check.spec.js
@@ -12,46 +12,46 @@ ruleOptions[ruldId] = {
   },
 }
 
-describe('Rules: ' + ruldId, function () {
-  it('Tag <a> should have requered attrs [title, href]', function () {
+describe('Rules: ' + ruldId, () => {
+  it('Tag <a> should have requered attrs [title, href]', () => {
     var code = '<a>blabla</a>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[1].rule.id).to.be(ruldId)
   })
-  it('Tag <a> should not be selfclosing', function () {
+  it('Tag <a> should not be selfclosing', () => {
     var code = '<a href="bbb" title="aaa"/>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
-  it('Tag <img> should be selfclosing', function () {
+  it('Tag <img> should be selfclosing', () => {
     var code = '<img src="bbb" title="aaa" alt="asd"></img>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
-  it('Should check optional attributes', function () {
+  it('Should check optional attributes', () => {
     var code = '<script src="aaa" async="sad" />'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
-  it('Should check redunant attributes', function () {
+  it('Should check redunant attributes', () => {
     var code = '<main role="main" />'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[1].rule.id).to.be(ruldId)
   })
-  it('Should be extendable trought config', function () {
+  it('Should be extendable trought config', () => {
     var code = '<sometag></sometag>'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
   })
-  it('Should check required attributes with specifyed values', function () {
+  it('Should check required attributes with specifyed values', () => {
     var code = '<sometag attrname="attrvalue" />'
     var messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/title-require.spec.js
+++ b/test/rules/title-require.spec.js
@@ -7,14 +7,14 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe(`Rules: ${ruldId}`, function () {
-  it('<title> be present in <head> tag should not result in an error', function () {
+describe(`Rules: ${ruldId}`, () => {
+  it('<title> be present in <head> tag should not result in an error', () => {
     const code = '<html><head><title>test</title></head><body></body></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('<title> not be present in <head> tag should result in an error', function () {
+  it('<title> not be present in <head> tag should result in an error', () => {
     let code = '<html><head></head><body></body></html>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
@@ -28,13 +28,13 @@ describe(`Rules: ${ruldId}`, function () {
     expect(messages.length).to.be(1)
   })
 
-  it('No head should not result in an error', function () {
+  it('No head should not result in an error', () => {
     const code = '<html><body></body></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
-  it('<title></title> is empty should result in an error', function () {
+  it('<title></title> is empty should result in an error', () => {
     let code = '<html><head><title></title></head><body></body></html>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)


### PR DESCRIPTION
***Short description of what this resolves:***

Modernize the code and use `es6` arrow functions

***Proposed changes:***

- Apply eslint rule [prefer-arrow-callback](https://eslint.org/docs/rules/prefer-arrow-callback)
- Apply eslint rule [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style)
- Don't assign `this` to variable called `self`