### PR TITLE
chore: modernize code / prefer-template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'no-useless-concat': 'error',
     'one-var': ['error', 'never'],
     'prefer-template': 'error',
+    quotes: ['error', 'single', { avoidEscape: true }],
     'template-curly-spacing': 'error',
     'template-tag-spacing': 'error',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,11 @@ module.exports = {
     sourceType: 'module',
   },
   rules: {
+    'no-template-curly-in-string': 'error',
+    'no-useless-concat': 'error',
     'one-var': ['error', 'never'],
+    'prefer-template': 'error',
+    'template-curly-spacing': 'error',
+    'template-tag-spacing': 'error',
   },
 }

--- a/bin/formatters/checkstyle.js
+++ b/bin/formatters/checkstyle.js
@@ -17,7 +17,7 @@ var checkstyleFormatter = function (formatter) {
               column: message.col,
               severity: message.type,
               message: message.message,
-              source: 'htmlhint.' + message.rule.id,
+              source: `htmlhint.${message.rule.id}`,
             },
           },
         })

--- a/bin/formatters/default.js
+++ b/bin/formatters/default.js
@@ -12,7 +12,7 @@ var defaultFormatter = function (formatter, HTMLHint, options) {
   })
 
   formatter.on('file', function (event) {
-    console.log('   ' + event.file.white)
+    console.log(`   ${event.file.white}`)
 
     var arrLogs = HTMLHint.format(event.messages, {
       colors: nocolor ? false : true,

--- a/bin/formatters/html.js
+++ b/bin/formatters/html.js
@@ -4,31 +4,20 @@ var htmlFormatter = function (formatter) {
   formatter.on('end', function (event) {
     var fileContent
     fileContent = '<html>'
-    fileContent =
-      fileContent + '<head><title>HTML Hint Violation Report</title></head>'
-    fileContent = fileContent + '<body>'
-    fileContent = fileContent + '<center><h2>Violation Report</h2></center>'
+    fileContent = `${fileContent}<head><title>HTML Hint Violation Report</title></head>`
+    fileContent = `${fileContent}<body>`
+    fileContent = `${fileContent}<center><h2>Violation Report</h2></center>`
 
-    fileContent = fileContent + '<table border = 1>'
-    fileContent =
-      fileContent +
-      '<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>'
+    fileContent = `${fileContent}<table border = 1>`
+    fileContent = `${fileContent}<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>`
 
     var arrAllMessages = event.arrAllMessages
     arrAllMessages.forEach(function (fileInfo) {
       var arrMessages = fileInfo.messages
       arrMessages.forEach(function (message, i) {
-        fileContent =
-          fileContent +
-          '<tr><td>' +
-          (i + 1) +
-          '</td><td>' +
-          fileInfo.file +
-          '</td><td>' +
-          message.line +
-          '</td><td>' +
-          message.message +
-          '</td></tr>'
+        fileContent = `${fileContent}<tr><td>${i + 1}</td><td>${
+          fileInfo.file
+        }</td><td>${message.line}</td><td>${message.message}</td></tr>`
       })
     })
 

--- a/bin/formatters/html.js
+++ b/bin/formatters/html.js
@@ -4,12 +4,13 @@ var htmlFormatter = function (formatter) {
   formatter.on('end', function (event) {
     var fileContent
     fileContent = '<html>'
-    fileContent += `<head><title>HTML Hint Violation Report</title></head>`
-    fileContent += `<body>`
-    fileContent += `<center><h2>Violation Report</h2></center>`
+    fileContent += '<head><title>HTML Hint Violation Report</title></head>'
+    fileContent += '<body>'
+    fileContent += '<center><h2>Violation Report</h2></center>'
 
-    fileContent += `<table border = 1>`
-    fileContent += `<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>`
+    fileContent += '<table border = 1>'
+    fileContent +=
+      '<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>'
 
     var arrAllMessages = event.arrAllMessages
     arrAllMessages.forEach(function (fileInfo) {

--- a/bin/formatters/html.js
+++ b/bin/formatters/html.js
@@ -4,20 +4,20 @@ var htmlFormatter = function (formatter) {
   formatter.on('end', function (event) {
     var fileContent
     fileContent = '<html>'
-    fileContent = `${fileContent}<head><title>HTML Hint Violation Report</title></head>`
-    fileContent = `${fileContent}<body>`
-    fileContent = `${fileContent}<center><h2>Violation Report</h2></center>`
+    fileContent += `<head><title>HTML Hint Violation Report</title></head>`
+    fileContent += `<body>`
+    fileContent += `<center><h2>Violation Report</h2></center>`
 
-    fileContent = `${fileContent}<table border = 1>`
-    fileContent = `${fileContent}<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>`
+    fileContent += `<table border = 1>`
+    fileContent += `<tr><th>Number#</th><th>File Name</th><th>Line Number</th><th>Message</th></tr>`
 
     var arrAllMessages = event.arrAllMessages
     arrAllMessages.forEach(function (fileInfo) {
       var arrMessages = fileInfo.messages
       arrMessages.forEach(function (message, i) {
-        fileContent = `${fileContent}<tr><td>${i + 1}</td><td>${
-          fileInfo.file
-        }</td><td>${message.line}</td><td>${message.message}</td></tr>`
+        fileContent += `<tr><td>${i + 1}</td><td>${fileInfo.file}</td><td>${
+          message.line
+        }</td><td>${message.message}</td></tr>`
       })
     })
 

--- a/bin/formatters/junit.js
+++ b/bin/formatters/junit.js
@@ -20,7 +20,7 @@ var junitFormatter = function (formatter, HTMLHint) {
           {
             failure: {
               _attr: {
-                message: 'Found ' + arrMessages.length + ' errors',
+                message: `Found ${arrMessages.length} errors`,
               },
               _cdata: arrLogs.join('\r\n'),
             },

--- a/bin/formatters/markdown.js
+++ b/bin/formatters/markdown.js
@@ -20,23 +20,21 @@ var markdownFormatter = function (formatter, HTMLHint) {
         }
       })
 
-      arrToc.push('   - [' + filePath + '](#' + filePath + ')')
-      arrContents.push('<a name="' + filePath + '" />')
-      arrContents.push('# ' + filePath)
+      arrToc.push(`   - [${filePath}](#${filePath})`)
+      arrContents.push(`<a name="${filePath}" />`)
+      arrContents.push(`# ${filePath}`)
       arrContents.push('')
-      arrContents.push(
-        'Found ' + errorCount + ' errors, ' + warningCount + ' warnings'
-      )
+      arrContents.push(`Found ${errorCount} errors, ${warningCount} warnings`)
 
       var arrLogs = HTMLHint.format(arrMessages)
       arrContents.push('')
       arrLogs.forEach(function (log) {
-        arrContents.push('    ' + log)
+        arrContents.push(`    ${log}`)
       })
       arrContents.push('')
     })
 
-    console.log(arrToc.join('\r\n') + '\r\n')
+    console.log(`${arrToc.join('\r\n')}\r\n`)
     console.log(arrContents.join('\r\n'))
   })
 }

--- a/bin/formatters/unix.js
+++ b/bin/formatters/unix.js
@@ -7,13 +7,7 @@ var unixFormatter = function (formatter, HTMLHint, options) {
           event.file,
           message.line,
           message.col,
-          ' ' +
-            message.message +
-            ' [' +
-            message.type +
-            '/' +
-            message.rule.id +
-            ']',
+          ` ${message.message} [${message.type}/${message.rule.id}]`,
         ].join(':')
       )
     })

--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -61,7 +61,7 @@ program
     'load custom rules from file or folder'
   )
   .option(
-    '-f, --format <' + arrSupportedFormatters.join('|') + '>',
+    `-f, --format <${arrSupportedFormatters.join('|')}>`,
     'output messages as custom format'
   )
   .option(
@@ -305,12 +305,12 @@ function getGlobInfo(target) {
   } else {
     // no basename
     if (globPath.basename === '') {
-      pattern += '**/' + defaultGlob
+      pattern += `**/${defaultGlob}`
     }
     // detect directory
     else if (fs.existsSync(target) && fs.statSync(target).isDirectory()) {
-      base += globPath.basename + '/'
-      pattern = '**/' + defaultGlob
+      base += `${globPath.basename}/`
+      pattern = `**/${defaultGlob}`
     }
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -110,7 +110,7 @@ class HTMLHintCore {
 
       // add ...
       if (leftCol > 1) {
-        evidence = '...' + evidence
+        evidence = `...${evidence}`
         leftCol -= 3
       }
       if (rightCol < evidenceCount) {
@@ -119,14 +119,9 @@ class HTMLHintCore {
 
       // show evidence
       arrLogs.push(
-        colors.white +
-          repeatStr(indent) +
-          'L' +
-          line +
-          ' |' +
-          colors.grey +
-          evidence +
-          colors.reset
+        `${colors.white + repeatStr(indent)}L${line} |${
+          colors.grey
+        }${evidence}${colors.reset}`
       )
 
       // show pointer & message
@@ -139,16 +134,11 @@ class HTMLHintCore {
       }
 
       arrLogs.push(
-        colors.white +
+        `${
+          colors.white +
           repeatStr(indent) +
-          repeatStr(String(line).length + 3 + pointCol) +
-          '^ ' +
-          colors.red +
-          hint.message +
-          ' (' +
-          hint.rule.id +
-          ')' +
-          colors.reset
+          repeatStr(String(line).length + 3 + pointCol)
+        }^ ${colors.red}${hint.message} (${hint.rule.id})${colors.reset}`
       )
     })
 

--- a/src/core.js
+++ b/src/core.js
@@ -37,7 +37,7 @@ class HTMLHintCore {
         ruleset = {}
       }
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-useless-escape
       strRuleset.replace(/(?:^|,)\s*([^:,]+)\s*(?:\:\s*([^,\s]+))?/g, function (
         all,
         key,
@@ -127,7 +127,7 @@ class HTMLHintCore {
       // show pointer & message
       var pointCol = col - leftCol
       // add double byte character
-      //eslint-disable-next-line
+      // eslint-disable-next-line no-control-regex
       var match = evidence.substring(0, pointCol).match(/[^\u0000-\u00ff]/g)
       if (match !== null) {
         pointCol += match.length

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -23,7 +23,7 @@ class HTMLParser {
 
     // eslint-disable-next-line
     var regTag = /<(?:\/([^\s>]+)\s*|!--([\s\S]*?)--|!([^>]*?)|([\w\-:]+)((?:\s+[^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]*))?)*?)\s*(\/?))>/g,
-      // eslint-disable-next-line no-control-regex
+      // eslint-disable-next-line no-control-regex, no-useless-escape
       regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g,
       regLine = /\r?\n/g
 

--- a/src/htmlparser.js
+++ b/src/htmlparser.js
@@ -23,7 +23,7 @@ class HTMLParser {
 
     // eslint-disable-next-line
     var regTag = /<(?:\/([^\s>]+)\s*|!--([\s\S]*?)--|!([^>]*?)|([\w\-:]+)((?:\s+[^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'>]*))?)*?)\s*(\/?))>/g,
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-control-regex
       regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g,
       regLine = /\r?\n/g
 
@@ -60,7 +60,7 @@ class HTMLParser {
       arrBlocks.push(data)
       self.fire(type, data)
 
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-unused-vars
       var lineMatch
       while ((lineMatch = regLine.exec(raw))) {
         line++

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -44,7 +44,7 @@ class Reporter {
       rule: {
         id: rule.id,
         description: rule.description,
-        link: 'https://github.com/thedaviddias/HTMLHint/wiki/' + rule.id,
+        link: `https://github.com/thedaviddias/HTMLHint/wiki/${rule.id}`,
       },
     })
   }

--- a/src/rules/alt-require.js
+++ b/src/rules/alt-require.js
@@ -25,7 +25,7 @@ export default {
         if (!('alt' in mapAttrs) || mapAttrs['alt'] === '') {
           selector = tagName === 'area' ? 'area[href]' : 'input[type=image]'
           reporter.warn(
-            'The alt attribute of ' + selector + ' must have a value.',
+            `The alt attribute of ${selector} must have a value.`,
             event.line,
             col,
             self,

--- a/src/rules/attr-lowercase.js
+++ b/src/rules/attr-lowercase.js
@@ -59,7 +59,7 @@ export default {
           attrName !== attrName.toLowerCase()
         ) {
           reporter.error(
-            'The attribute name of [ ' + attrName + ' ] must be in lowercase.',
+            `The attribute name of [ ${attrName} ] must be in lowercase.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-no-duplication.js
+++ b/src/rules/attr-no-duplication.js
@@ -18,7 +18,7 @@ export default {
 
         if (mapAttrName[attrName] === true) {
           reporter.error(
-            'Duplicate of attribute name [ ' + attr.name + ' ] was found.',
+            `Duplicate of attribute name [ ${attr.name} ] was found.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -14,9 +14,7 @@ export default {
           var match = /(\s*)=(\s*)/.exec(attrs[i].raw.trim())
           if (match && (match[1].length !== 0 || match[2].length !== 0)) {
             reporter.error(
-              "The attribute '" +
-                attrs[i].name +
-                "' must not have spaces between the name and value.",
+              `The attribute '${attrs[i].name}' must not have spaces between the name and value.`,
               event.line,
               col + attrs[i].index,
               self,

--- a/src/rules/attr-sorted.js
+++ b/src/rules/attr-sorted.js
@@ -45,11 +45,9 @@ export default {
 
       if (originalAttrs !== JSON.stringify(listOfAttributes)) {
         reporter.error(
-          'Inaccurate order ' +
-            originalAttrs +
-            ' should be in hierarchy ' +
-            JSON.stringify(listOfAttributes) +
-            ' ',
+          `Inaccurate order ${originalAttrs} should be in hierarchy ${JSON.stringify(
+            listOfAttributes
+          )} `,
           event.line,
           event.col,
           self

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -22,11 +22,7 @@ export default {
             .replace(/%u/, '\\u')
             .replace(/%/, '\\x')
           reporter.warn(
-            'The value of attribute [ ' +
-              attr.name +
-              ' ] cannot contain an unsafe char [ ' +
-              unsafeCode +
-              ' ].',
+            `The value of attribute [ ${attr.name} ] cannot contain an unsafe char [ ${unsafeCode} ].`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-unsafe-chars.js
+++ b/src/rules/attr-unsafe-chars.js
@@ -9,7 +9,7 @@ export default {
       var attr
       var col = event.col + event.tagName.length + 1
       // exclude \x09(\t), \x0a(\r), \x0d(\n)
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-misleading-character-class, no-control-regex
       var regUnsafe = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/
       var match
 

--- a/src/rules/attr-value-double-quotes.js
+++ b/src/rules/attr-value-double-quotes.js
@@ -17,9 +17,7 @@ export default {
           (attr.value === '' && attr.quote === "'")
         ) {
           reporter.error(
-            'The value of attribute [ ' +
-              attr.name +
-              ' ] must be in double quotes.',
+            `The value of attribute [ ${attr.name} ] must be in double quotes.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-value-not-empty.js
+++ b/src/rules/attr-value-not-empty.js
@@ -14,7 +14,7 @@ export default {
 
         if (attr.quote === '' && attr.value === '') {
           reporter.warn(
-            'The attribute [ ' + attr.name + ' ] must have a value.',
+            `The attribute [ ${attr.name} ] must have a value.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-value-single-quotes.js
+++ b/src/rules/attr-value-single-quotes.js
@@ -17,9 +17,7 @@ export default {
           (attr.value === '' && attr.quote === '"')
         ) {
           reporter.error(
-            'The value of attribute [ ' +
-              attr.name +
-              ' ] must be in single quotes.',
+            `The value of attribute [ ${attr.name} ] must be in single quotes.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/attr-whitespace.js
+++ b/src/rules/attr-whitespace.js
@@ -22,9 +22,7 @@ export default {
         //Check first and last characters for spaces
         if (elem.value.trim(elem.value) !== elem.value) {
           reporter.error(
-            'The attributes of [ ' +
-              attrName +
-              ' ] must not have trailing whitespace.',
+            `The attributes of [ ${attrName} ] must not have trailing whitespace.`,
             event.line,
             col + attr.index,
             self,
@@ -34,9 +32,7 @@ export default {
 
         if (elem.value.replace(/ +(?= )/g, '') !== elem.value) {
           reporter.error(
-            'The attributes of [ ' +
-              attrName +
-              ' ] must be separated by only one space.',
+            `The attributes of [ ${attrName} ] must be separated by only one space.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/href-abs-or-rel.js
+++ b/src/rules/href-abs-or-rel.js
@@ -21,11 +21,7 @@ export default {
               /^https?:\/\//.test(attr.value) === true)
           ) {
             reporter.warn(
-              'The value of the href attribute [ ' +
-                attr.value +
-                ' ] must be ' +
-                hrefMode +
-                '.',
+              `The value of the href attribute [ ${attr.value} ] must be ${hrefMode}.`,
               event.line,
               col + attr.index,
               self,

--- a/src/rules/id-class-ad-disabled.js
+++ b/src/rules/id-class-ad-disabled.js
@@ -18,9 +18,7 @@ export default {
         if (/^(id|class)$/i.test(attrName)) {
           if (/(^|[-_])ad([-_]|$)/i.test(attr.value)) {
             reporter.warn(
-              'The value of attribute ' +
-                attrName +
-                ' cannot use the ad keyword.',
+              `The value of attribute ${attrName} cannot use the ad keyword.`,
               event.line,
               col + attr.index,
               self,

--- a/src/rules/id-unique.js
+++ b/src/rules/id-unique.js
@@ -26,7 +26,7 @@ export default {
 
             if (mapIdCount[id] > 1) {
               reporter.error(
-                'The id value [ ' + id + ' ] must be unique.',
+                `The id value [ ${id} ] must be unique.`,
                 event.line,
                 col + attr.index,
                 self,

--- a/src/rules/inline-script-disabled.js
+++ b/src/rules/inline-script-disabled.js
@@ -17,7 +17,7 @@ export default {
 
         if (reEvent.test(attrName) === true) {
           reporter.warn(
-            'Inline script [ ' + attr.raw + ' ] cannot be used.',
+            `Inline script [ ${attr.raw} ] cannot be used.`,
             event.line,
             col + attr.index,
             self,
@@ -26,7 +26,7 @@ export default {
         } else if (attrName === 'src' || attrName === 'href') {
           if (/^\s*javascript:/i.test(attr.value)) {
             reporter.warn(
-              'Inline script [ ' + attr.raw + ' ] cannot be used.',
+              `Inline script [ ${attr.raw} ] cannot be used.`,
               event.line,
               col + attr.index,
               self,

--- a/src/rules/inline-style-disabled.js
+++ b/src/rules/inline-style-disabled.js
@@ -14,7 +14,7 @@ export default {
 
         if (attr.name.toLowerCase() === 'style') {
           reporter.warn(
-            'Inline style [ ' + attr.raw + ' ] cannot be used.',
+            `Inline style [ ${attr.raw} ] cannot be used.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/space-tab-mixed-disabled.js
+++ b/src/rules/space-tab-mixed-disabled.js
@@ -31,9 +31,7 @@ export default {
               whiteSpace.length % spaceLengthRequire !== 0
             ) {
               reporter.warn(
-                'Please use space for indentation and keep ' +
-                  spaceLengthRequire +
-                  ' length.',
+                `Please use space for indentation and keep ${spaceLengthRequire} length.`,
                 fixedPos.line,
                 1,
                 self,

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -7,7 +7,7 @@ export default {
     parser.addListener('text', function (event) {
       var raw = event.raw
       // TODO: improve use-cases for &
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-useless-escape
       var reSpecChar = /([<>])|( \& )/g
       var match
 

--- a/src/rules/spec-char-escape.js
+++ b/src/rules/spec-char-escape.js
@@ -14,7 +14,7 @@ export default {
       while ((match = reSpecChar.exec(raw))) {
         var fixedPos = parser.fixPos(event, match.index)
         reporter.error(
-          'Special characters must be escaped : [ ' + match[0] + ' ].',
+          `Special characters must be escaped : [ ${match[0]} ].`,
           fixedPos.line,
           fixedPos.col,
           self,

--- a/src/rules/src-not-empty.js
+++ b/src/rules/src-not-empty.js
@@ -21,11 +21,7 @@ export default {
           attr.value === ''
         ) {
           reporter.error(
-            'The attribute [ ' +
-              attr.name +
-              ' ] of the tag [ ' +
-              tagName +
-              ' ] must have a value.',
+            `The attribute [ ${attr.name} ] of the tag [ ${tagName} ] must have a value.`,
             event.line,
             col + attr.index,
             self,

--- a/src/rules/tag-pair.js
+++ b/src/rules/tag-pair.js
@@ -32,19 +32,17 @@ export default {
       if (pos >= 0) {
         var arrTags = []
         for (var i = stack.length - 1; i > pos; i--) {
-          arrTags.push('</' + stack[i].tagName + '>')
+          arrTags.push(`</${stack[i].tagName}>`)
         }
 
         if (arrTags.length > 0) {
           var lastEvent = stack[stack.length - 1]
           reporter.error(
-            'Tag must be paired, missing: [ ' +
-              arrTags.join('') +
-              ' ], start tag match failed [ ' +
-              lastEvent.raw +
-              ' ] on line ' +
-              lastEvent.line +
-              '.',
+            `Tag must be paired, missing: [ ${arrTags.join(
+              ''
+            )} ], start tag match failed [ ${lastEvent.raw} ] on line ${
+              lastEvent.line
+            }.`,
             event.line,
             event.col,
             self,
@@ -54,7 +52,7 @@ export default {
         stack.length = pos
       } else {
         reporter.error(
-          'Tag must be paired, no start tag: [ ' + event.raw + ' ]',
+          `Tag must be paired, no start tag: [ ${event.raw} ]`,
           event.line,
           event.col,
           self,
@@ -67,19 +65,17 @@ export default {
       var arrTags = []
 
       for (var i = stack.length - 1; i >= 0; i--) {
-        arrTags.push('</' + stack[i].tagName + '>')
+        arrTags.push(`</${stack[i].tagName}>`)
       }
 
       if (arrTags.length > 0) {
         var lastEvent = stack[stack.length - 1]
         reporter.error(
-          'Tag must be paired, missing: [ ' +
-            arrTags.join('') +
-            ' ], open tag match failed [ ' +
-            lastEvent.raw +
-            ' ] on line ' +
-            lastEvent.line +
-            '.',
+          `Tag must be paired, missing: [ ${arrTags.join(
+            ''
+          )} ], open tag match failed [ ${lastEvent.raw} ] on line ${
+            lastEvent.line
+          }.`,
           event.line,
           event.col,
           self,

--- a/src/rules/tag-self-close.js
+++ b/src/rules/tag-self-close.js
@@ -12,7 +12,7 @@ export default {
       if (mapEmptyTags[tagName] !== undefined) {
         if (!event.close) {
           reporter.warn(
-            'The empty tag : [ ' + tagName + ' ] must be self closed.',
+            `The empty tag : [ ${tagName} ] must be self closed.`,
             event.line,
             event.col,
             self,

--- a/src/rules/tagname-lowercase.js
+++ b/src/rules/tagname-lowercase.js
@@ -12,7 +12,7 @@ export default {
         tagName !== tagName.toLowerCase()
       ) {
         reporter.error(
-          'The html element name of [ ' + tagName + ' ] must be in lowercase.',
+          `The html element name of [ ${tagName} ] must be in lowercase.`,
           event.line,
           event.col,
           self,

--- a/src/rules/tagname-specialchars.js
+++ b/src/rules/tagname-specialchars.js
@@ -9,9 +9,7 @@ export default {
       var tagName = event.tagName
       if (specialchars.test(tagName)) {
         reporter.error(
-          'The html element name of [ ' +
-            tagName +
-            ' ] contains special character.',
+          `The html element name of [ ${tagName} ] contains special character.`,
           event.line,
           event.col,
           self,

--- a/src/rules/tags-check.js
+++ b/src/rules/tags-check.js
@@ -61,7 +61,7 @@ export default {
 
         if (currentTagType.selfclosing === true && !event.close) {
           reporter.warn(
-            'The <' + tagName + '> tag must be selfclosing.',
+            `The <${tagName}> tag must be selfclosing.`,
             event.line,
             event.col,
             self,
@@ -69,7 +69,7 @@ export default {
           )
         } else if (currentTagType.selfclosing === false && event.close) {
           reporter.warn(
-            'The <' + tagName + '> tag must not be selfclosing.',
+            `The <${tagName}> tag must not be selfclosing.`,
             event.line,
             event.col,
             self,
@@ -97,13 +97,9 @@ export default {
                     values.indexOf(attr.value) === -1
                   ) {
                     reporter.error(
-                      'The <' +
-                        tagName +
-                        "> tag must have attr '" +
-                        realID +
-                        "' with one value of '" +
-                        values.join("' or '") +
-                        "'.",
+                      `The <${tagName}> tag must have attr '${realID}' with one value of '${values.join(
+                        "' or '"
+                      )}'.`,
                       event.line,
                       col,
                       self,
@@ -113,7 +109,7 @@ export default {
                 })
               } else {
                 reporter.error(
-                  'The <' + tagName + "> tag must have attr '" + realID + "'.",
+                  `The <${tagName}> tag must have attr '${realID}'.`,
                   event.line,
                   col,
                   self,
@@ -126,7 +122,7 @@ export default {
               })
             ) {
               reporter.error(
-                'The <' + tagName + "> tag must have attr '" + id + "'.",
+                `The <${tagName}> tag must have attr '${id}'.`,
                 event.line,
                 col,
                 self,
@@ -156,13 +152,9 @@ export default {
                     values.indexOf(attr.value) === -1
                   ) {
                     reporter.error(
-                      'The <' +
-                        tagName +
-                        "> tag must have optional attr '" +
-                        realID +
-                        "' with one value of '" +
-                        values.join("' or '") +
-                        "'.",
+                      `The <${tagName}> tag must have optional attr '${realID}' with one value of '${values.join(
+                        "' or '"
+                      )}'.`,
                       event.line,
                       col,
                       self,
@@ -183,11 +175,7 @@ export default {
               })
             ) {
               reporter.error(
-                "The attr '" +
-                  attrName +
-                  "' is redundant for <" +
-                  tagName +
-                  '> and should be ommited.',
+                `The attr '${attrName}' is redundant for <${tagName}> and should be ommited.`,
                 event.line,
                 col,
                 self,

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -7,7 +7,7 @@ var ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Attribute with spaces should result in an error', function () {
     var codes = [
       '<div title = "a" />',

--- a/test/rules/attr-value-single-quotes.spec.js
+++ b/test/rules/attr-value-single-quotes.spec.js
@@ -7,7 +7,7 @@ const ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Attribute value closed by double quotes should result in an error', function () {
     var code = '<a href="abc" title=abc style="">'
     var messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -16,7 +16,7 @@ ruleOptionsReg[ruldId] = {
   message: 'Id and class value must meet regexp',
 }
 
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Id and class value be not lower case and split by underline should result in an error', function () {
     var code = '<div id="aaaBBB" class="ccc-ddd">'
     var messages = HTMLHint.verify(code, ruleOptionsUnderline)

--- a/test/rules/script-disabled.spec.js
+++ b/test/rules/script-disabled.spec.js
@@ -3,7 +3,7 @@ var HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 var ruldId = 'script-disabled'
 var ruleOptions = {}
 ruleOptions[ruldId] = true
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Add external script file should result in an error', function () {
     var code = '<body><script src="test.js"></script></body>'
     var messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -7,7 +7,7 @@ var ruleOptions = {}
 
 ruleOptions[ruldId] = true
 
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Special characters: <> should result in an error', function () {
     var code = '<p>aaa>bbb< ccc</p>ddd\r\neee<'
     var messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/tags-check.spec.js
+++ b/test/rules/tags-check.spec.js
@@ -12,7 +12,7 @@ ruleOptions[ruldId] = {
   },
 }
 
-describe('Rules: ' + ruldId, function () {
+describe(`Rules: ${ruldId}`, function () {
   it('Tag <a> should have requered attrs [title, href]', function () {
     var code = '<a>blabla</a>'
     var messages = HTMLHint.verify(code, ruleOptions)


### PR DESCRIPTION
***Short description of what this resolves:***

Modernize the code and use `es6` `template-literals`

***Proposed changes:***

- Apply eslint rule [prefer-template](https://eslint.org/docs/rules/prefer-template)
- Apply eslint rule [no-useless-concat](https://eslint.org/docs/rules/no-useless-concat)
- Apply eslint rule [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
- Apply eslint rule [template-curly-spacing](https://eslint.org/docs/rules/template-curly-spacing)
- Apply eslint rule [template-tag-spacing](https://eslint.org/docs/rules/template-tag-spacing)
- Apply eslint rule [quotes](https://eslint.org/docs/rules/quotes)