### PR TITLE
fix(attr-no-unnecessary-whitespace): fix when equals symbol in value

### DIFF
--- a/src/rules/attr-no-unnecessary-whitespace.js
+++ b/src/rules/attr-no-unnecessary-whitespace.js
@@ -10,19 +10,19 @@ export default {
       var col = event.col + event.tagName.length + 1
 
       for (var i = 0; i < attrs.length; i++) {
-        if (
-          exceptions.indexOf(attrs[i].name) === -1 &&
-          /[^=](\s+=\s+|=\s+|\s+=)/g.test(attrs[i].raw.trim())
-        ) {
-          reporter.error(
-            "The attribute '" +
-              attrs[i].name +
-              "' must not have spaces between the name and value.",
-            event.line,
-            col + attrs[i].index,
-            self,
-            attrs[i].raw
-          )
+        if (exceptions.indexOf(attrs[i].name) === -1) {
+          var match = /(\s*)=(\s*)/.exec(attrs[i].raw.trim())
+          if (match && (match[1].length !== 0 || match[2].length !== 0)) {
+            reporter.error(
+              "The attribute '" +
+                attrs[i].name +
+                "' must not have spaces between the name and value.",
+              event.line,
+              col + attrs[i].index,
+              self,
+              attrs[i].raw
+            )
+          }
         }
       }
     })

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -24,8 +24,10 @@ describe('Rules: ' + ruldId, function () {
   })
 
   it('Attribute without spaces should not result in an error', function () {
-    var code = '<div title="a" />'
-    var messages = HTMLHint.verify(code, ruleOptions)
-    expect(messages.length).to.be(0)
+    var codes = ['<div title="a" />', '<div title="a = a" />']
+    for (var i = 0; i < codes.length; i++) {
+      var messages = HTMLHint.verify(codes[i], ruleOptions)
+      expect(messages.length).to.be(0)
+    }
   })
 })


### PR DESCRIPTION
***Short description of what this resolves:***
The new "attr-no-unnecessary-whitespace" rule is not working correctly when there is equals symbol in the value, e.g.:
```html
<div title="a = a" />
```
Also the test file was wrongly named ".js" instead of ".spec.js".

***Proposed changes:***
Only the first "=" is checked and the test file is renamed correctly.
