### PR TITLE
fix: correctly call hint queue drain

### DIFF
--- a/bin/htmlhint
+++ b/bin/htmlhint
@@ -248,10 +248,10 @@ function hintAllFiles(target, options, onFinised) {
   // start hint
   var isWalkDone = false
   var isHintDone = true
-  hintQueue.drain = function () {
+  hintQueue.drain(() => {
     isHintDone = true
     checkAllHinted()
-  }
+  })
 
   function checkAllHinted() {
     if (isWalkDone && isHintDone) {

--- a/test/executable.spec.js
+++ b/test/executable.spec.js
@@ -36,4 +36,34 @@ describe('Executable', () => {
       expect(stdoutEnd || processEnd).to.be(false)
     })
   })
+
+  for (const format of [
+    'checkstyle',
+    'compact',
+    'default',
+    'html',
+    'json',
+    'junit',
+    'markdown',
+    'unix',
+  ]) {
+    it(`should have stdout output with formatter ${format}`, (done) => {
+      ChildProcess.exec(
+        [
+          'node',
+          path.resolve(__dirname, '../bin/htmlhint'),
+          path.resolve(__dirname, './html/executable.html'),
+          '--format',
+          'json',
+        ].join(' '),
+        (error, stdout, stderr) => {
+          expect(error).to.be.an('object')
+          expect(error.code).to.be.equal(1)
+          expect(stdout).not.to.be.equal('')
+          expect(stderr).to.be.equal('')
+          done()
+        }
+      )
+    })
+  }
 })


### PR DESCRIPTION
***Short description of what this resolves:***

The hint queue `drain`-function was incorrectly reassigned instead of being invoked.

***Proposed changes:***

- Invoke the `drain`-function correctly