### PR TITLE
fix: windows path separator

### DIFF
--- a/src/cli/htmlhint.ts
+++ b/src/cli/htmlhint.ts
@@ -6,6 +6,7 @@ import * as program from 'commander'
 import { existsSync, readFileSync, statSync } from 'fs'
 import * as glob from 'glob'
 import { IGlob } from 'glob'
+import { type as osType } from 'os'
 import * as parseGlob from 'parse-glob'
 import { dirname, resolve, sep } from 'path'
 import * as request from 'request'
@@ -18,6 +19,8 @@ const HTMLHint: typeof IHTMLHint = require('../htmlhint.js').HTMLHint
 const formatter: Formatter = require('./formatter')
 
 const pkg = require('../../package.json')
+
+const OS_TYPE = osType()
 
 function map(val: string) {
   const objMap: { [name: string]: string | true } = {}
@@ -446,6 +449,11 @@ function walkPath(
 
   walk.on('match', (file: string) => {
     base = base.replace(/^.\//, '')
+
+    if (OS_TYPE === 'Windows_NT') {
+      base = base.replace(/\//g, '\\')
+    }
+
     callback(base + file)
   })
 }

--- a/test/cli/formatters/checkstyle.spec.js
+++ b/test/cli/formatters/checkstyle.spec.js
@@ -9,13 +9,7 @@ describe('CLI', () => {
     it('should have stdout output with formatter checkstyle', (done) => {
       const expected = fs
         .readFileSync(path.resolve(__dirname, 'checkstyle.xml'), 'utf8')
-        .replace(
-          '{{path}}',
-          path
-            .resolve(__dirname, 'example.html')
-            // TODO: we need to fix windows backslash
-            .replace('\\example', '/example')
-        )
+        .replace('{{path}}', path.resolve(__dirname, 'example.html'))
 
       const expectedParts = expected.split('\n')
 

--- a/test/cli/formatters/compact.spec.js
+++ b/test/cli/formatters/compact.spec.js
@@ -11,10 +11,7 @@ describe('CLI', () => {
         .readFileSync(path.resolve(__dirname, 'compact.txt'), 'utf8')
         .replace(
           /\{\{path\}\}/g,
-          path
-            .resolve(__dirname, '../../html/executable.html')
-            // TODO: we need to fix windows backslash
-            .replace('html\\executable.html', 'html/executable.html')
+          path.resolve(__dirname, '../../html/executable.html')
         )
         .replace(/\\u001b/g, '\u001b')
 

--- a/test/cli/formatters/html.spec.js
+++ b/test/cli/formatters/html.spec.js
@@ -9,13 +9,7 @@ describe('CLI', () => {
     it('should have stdout output with formatter html', (done) => {
       const expected = fs
         .readFileSync(path.resolve(__dirname, 'html.html'), 'utf8')
-        .replace(
-          /\{\{path\}\}/g,
-          path
-            .resolve(__dirname, 'example.html')
-            // TODO: we need to fix windows backslash
-            .replace('\\example', '/example')
-        )
+        .replace(/\{\{path\}\}/g, path.resolve(__dirname, 'example.html'))
 
       const expectedParts = expected.split('\n')
 

--- a/test/cli/formatters/unix.spec.js
+++ b/test/cli/formatters/unix.spec.js
@@ -11,10 +11,7 @@ describe('CLI', () => {
         .readFileSync(path.resolve(__dirname, 'unix.txt'), 'utf8')
         .replace(
           /\{\{path\}\}/g,
-          path
-            .resolve(__dirname, '../../html/executable.html')
-            // TODO: we need to fix windows backslash
-            .replace('html\\executable.html', 'html/executable.html')
+          path.resolve(__dirname, '../../html/executable.html')
         )
         .replace(/\\u001b/g, '\u001b')
 


### PR DESCRIPTION
***Short description of what this resolves:***

In windows files are separated with `\` instead of `/`
This fix implemented a detection for windows and fix the unix style `/` for windows reports

***Proposed changes:***

Use `\` as file separator in windows
