### PR TITLE
feat: new configuration structure

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -71,8 +71,9 @@ class HTMLHintCore {
         ? ruleConfig[0]
         : ruleConfig
       if (rule !== undefined && ruleSeverity !== 'off') {
-        const reportMessageCallback: ReportMessageCallback =
-          reporter[ruleSeverity]
+        const reportMessageCallback: ReportMessageCallback = reporter[
+          ruleSeverity
+        ].bind(reporter)
         rule.init(
           parser,
           reportMessageCallback,

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -11,16 +11,16 @@ export interface FormatOptions {
 class HTMLHintCore {
   public rules: { [id: string]: Rule } = {}
   public readonly defaultRuleset: Ruleset = {
-    'tagname-lowercase': true,
-    'attr-lowercase': true,
-    'attr-value-double-quotes': true,
-    'doctype-first': true,
-    'tag-pair': true,
-    'spec-char-escape': true,
-    'id-unique': true,
-    'src-not-empty': true,
-    'attr-no-duplication': true,
-    'title-require': true,
+    'tagname-lowercase': 'error',
+    'attr-lowercase': 'error',
+    'attr-value-double-quotes': 'error',
+    'doctype-first': 'error',
+    'tag-pair': 'error',
+    'spec-char-escape': 'error',
+    'id-unique': 'error',
+    'src-not-empty': 'error',
+    'attr-no-duplication': 'error',
+    'title-require': 'error',
   }
 
   public addRule(rule: Rule) {

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -73,7 +73,11 @@ class HTMLHintCore {
       if (rule !== undefined && ruleSeverity !== 'off') {
         const reportMessageCallback: ReportMessageCallback =
           reporter[ruleSeverity]
-        rule.init(parser, reportMessageCallback, ruleConfig)
+        rule.init(
+          parser,
+          reportMessageCallback,
+          Array.isArray(ruleConfig) ? ruleConfig[1] : undefined
+        )
       }
     }
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1,7 +1,7 @@
 import HTMLParser from './htmlparser'
 import Reporter, { ReportMessageCallback } from './reporter'
 import * as HTMLRules from './rules'
-import { Hint, Rule, Ruleset, RuleSeverity } from './types'
+import { Hint, isRuleSeverity, Rule, Ruleset, RuleSeverity } from './types'
 
 export interface FormatOptions {
   colors?: boolean
@@ -37,18 +37,17 @@ class HTMLHintCore {
       /^\s*<!--\s*htmlhint\s+([^\r\n]+?)\s*-->/i,
       (all, strRuleset: string) => {
         // For example:
-        // all is '<!-- htmlhint alt-require:true-->'
-        // strRuleset is 'alt-require:true'
+        // all is '<!-- htmlhint alt-require:warn-->'
+        // strRuleset is 'alt-require:warn'
         strRuleset.replace(
           /(?:^|,)\s*([^:,]+)\s*(?:\:\s*([^,\s]+))?/g,
           (all, ruleId: string, value: string | undefined) => {
             // For example:
-            // all is 'alt-require:true'
+            // all is 'alt-require:warn'
             // ruleId is 'alt-require'
-            // value is 'true'
+            // value is 'warn'
 
-            ruleset[ruleId] =
-              value !== undefined && value.length > 0 ? JSON.parse(value) : true
+            ruleset[ruleId] = isRuleSeverity(value) ? value : 'error'
 
             return ''
           }

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -66,7 +66,11 @@ class HTMLHintCore {
 
     for (const id in ruleset) {
       rule = rules[id]
-      if (rule !== undefined && ruleset[id] !== false) {
+      if (
+        rule !== undefined &&
+        (ruleset[id] !== 'off' ||
+          (Array.isArray(ruleset[id]) && ruleset[id] !== 'off'))
+      ) {
         rule.init(parser, reporter, ruleset[id])
       }
     }

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1,7 +1,7 @@
 import HTMLParser from './htmlparser'
-import Reporter from './reporter'
+import Reporter, { ReportMessageCallback } from './reporter'
 import * as HTMLRules from './rules'
-import { Hint, Rule, Ruleset } from './types'
+import { Hint, Rule, Ruleset, RuleSeverity } from './types'
 
 export interface FormatOptions {
   colors?: boolean
@@ -66,12 +66,14 @@ class HTMLHintCore {
 
     for (const id in ruleset) {
       rule = rules[id]
-      if (
-        rule !== undefined &&
-        (ruleset[id] !== 'off' ||
-          (Array.isArray(ruleset[id]) && ruleset[id] !== 'off'))
-      ) {
-        rule.init(parser, reporter, ruleset[id])
+      const ruleConfig = ruleset[id]
+      const ruleSeverity: RuleSeverity = Array.isArray(ruleConfig)
+        ? ruleConfig[0]
+        : ruleConfig
+      if (rule !== undefined && ruleSeverity !== 'off') {
+        const reportMessageCallback: ReportMessageCallback =
+          reporter[ruleSeverity]
+        rule.init(parser, reportMessageCallback, ruleConfig)
       }
     }
 

--- a/src/core/reporter.ts
+++ b/src/core/reporter.ts
@@ -1,5 +1,13 @@
 import { Hint, ReportType, Rule, Ruleset } from './types'
 
+export type ReportMessageCallback = (
+  message: string,
+  line: number,
+  col: number,
+  rule: Rule,
+  raw: string
+) => void
+
 export default class Reporter {
   public html: string
   public lines: string[]

--- a/src/core/rules/alt-require.ts
+++ b/src/core/rules/alt-require.ts
@@ -4,7 +4,7 @@ export default {
   id: 'alt-require',
   description:
     'The alt attribute of an <img> element must be present and alt attribute of area[href] and input[type=image] must have a value.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const tagName = event.tagName.toLowerCase()
       const mapAttrs = parser.getMapAttrs(event.attrs)
@@ -12,7 +12,7 @@ export default {
       let selector
 
       if (tagName === 'img' && !('alt' in mapAttrs)) {
-        reporter.warn(
+        reportMessageCallback(
           'An alt attribute must be present on <img> elements.',
           event.line,
           col,
@@ -25,7 +25,7 @@ export default {
       ) {
         if (!('alt' in mapAttrs) || mapAttrs['alt'] === '') {
           selector = tagName === 'area' ? 'area[href]' : 'input[type=image]'
-          reporter.warn(
+          reportMessageCallback(
             `The alt attribute of ${selector} must have a value.`,
             event.line,
             col,

--- a/src/core/rules/attr-lowercase.ts
+++ b/src/core/rules/attr-lowercase.ts
@@ -1,4 +1,4 @@
-import { Rule } from '../types'
+import { Rule, RuleConfig } from '../types'
 
 /**
  * testAgainstStringOrRegExp
@@ -42,8 +42,12 @@ function testAgainstStringOrRegExp(value: string, comparison: string | RegExp) {
 export default {
   id: 'attr-lowercase',
   description: 'All attribute names must be in lowercase.',
-  init(parser, reportMessageCallback, options) {
-    const exceptions = Array.isArray(options) ? options : []
+  init(
+    parser,
+    reportMessageCallback,
+    options?: { exceptions: Array<string | RegExp> }
+  ) {
+    const exceptions = options?.exceptions ?? []
 
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs

--- a/src/core/rules/attr-lowercase.ts
+++ b/src/core/rules/attr-lowercase.ts
@@ -42,7 +42,7 @@ function testAgainstStringOrRegExp(value: string, comparison: string | RegExp) {
 export default {
   id: 'attr-lowercase',
   description: 'All attribute names must be in lowercase.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const exceptions = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart', (event) => {
@@ -58,7 +58,7 @@ export default {
           !exceptions.find((exp) => testAgainstStringOrRegExp(attrName, exp)) &&
           attrName !== attrName.toLowerCase()
         ) {
-          reporter.error(
+          reportMessageCallback(
             `The attribute name of [ ${attrName} ] must be in lowercase.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-no-duplication.ts
+++ b/src/core/rules/attr-no-duplication.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-no-duplication',
   description: 'Elements cannot have duplicate attributes.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -17,7 +17,7 @@ export default {
         attrName = attr.name
 
         if (mapAttrName[attrName] === true) {
-          reporter.error(
+          reportMessageCallback(
             `Duplicate of attribute name [ ${attr.name} ] was found.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-no-unnecessary-whitespace.ts
+++ b/src/core/rules/attr-no-unnecessary-whitespace.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-no-unnecessary-whitespace',
   description: 'No spaces between attribute names and values.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const exceptions: string[] = Array.isArray(options) ? options : []
 
     parser.addListener('tagstart', (event) => {
@@ -14,7 +14,7 @@ export default {
         if (exceptions.indexOf(attrs[i].name) === -1) {
           const match = /(\s*)=(\s*)/.exec(attrs[i].raw.trim())
           if (match && (match[1].length !== 0 || match[2].length !== 0)) {
-            reporter.error(
+            reportMessageCallback(
               `The attribute '${attrs[i].name}' must not have spaces between the name and value.`,
               event.line,
               col + attrs[i].index,

--- a/src/core/rules/attr-no-unnecessary-whitespace.ts
+++ b/src/core/rules/attr-no-unnecessary-whitespace.ts
@@ -3,8 +3,8 @@ import { Rule } from '../types'
 export default {
   id: 'attr-no-unnecessary-whitespace',
   description: 'No spaces between attribute names and values.',
-  init(parser, reportMessageCallback, options) {
-    const exceptions: string[] = Array.isArray(options) ? options : []
+  init(parser, reportMessageCallback, options?: { exceptions: string[] }) {
+    const exceptions: string[] = options?.exceptions ?? []
 
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs

--- a/src/core/rules/attr-sorted.ts
+++ b/src/core/rules/attr-sorted.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-sorted',
   description: 'Attribute tags must be in proper order.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const orderMap: { [key: string]: number } = {}
     const sortOrder = [
       'class',
@@ -45,7 +45,7 @@ export default {
       })
 
       if (originalAttrs !== JSON.stringify(listOfAttributes)) {
-        reporter.error(
+        reportMessageCallback(
           `Inaccurate order ${originalAttrs} should be in hierarchy ${JSON.stringify(
             listOfAttributes
           )} `,

--- a/src/core/rules/attr-unsafe-chars.ts
+++ b/src/core/rules/attr-unsafe-chars.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-unsafe-chars',
   description: 'Attribute values cannot contain unsafe chars.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -21,7 +21,7 @@ export default {
           const unsafeCode = escape(match[0])
             .replace(/%u/, '\\u')
             .replace(/%/, '\\x')
-          reporter.warn(
+          reportMessageCallback(
             `The value of attribute [ ${attr.name} ] cannot contain an unsafe char [ ${unsafeCode} ].`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-value-double-quotes.ts
+++ b/src/core/rules/attr-value-double-quotes.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-value-double-quotes',
   description: 'Attribute values must be in double quotes.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -16,7 +16,7 @@ export default {
           (attr.value !== '' && attr.quote !== '"') ||
           (attr.value === '' && attr.quote === "'")
         ) {
-          reporter.error(
+          reportMessageCallback(
             `The value of attribute [ ${attr.name} ] must be in double quotes.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-value-not-empty.ts
+++ b/src/core/rules/attr-value-not-empty.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-value-not-empty',
   description: 'All attributes must have values.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -13,7 +13,7 @@ export default {
         attr = attrs[i]
 
         if (attr.quote === '' && attr.value === '') {
-          reporter.warn(
+          reportMessageCallback(
             `The attribute [ ${attr.name} ] must have a value.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-value-single-quotes.ts
+++ b/src/core/rules/attr-value-single-quotes.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'attr-value-single-quotes',
   description: 'Attribute values must be in single quotes.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -16,7 +16,7 @@ export default {
           (attr.value !== '' && attr.quote !== "'") ||
           (attr.value === '' && attr.quote === '"')
         ) {
-          reporter.error(
+          reportMessageCallback(
             `The value of attribute [ ${attr.name} ] must be in single quotes.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-whitespace.ts
+++ b/src/core/rules/attr-whitespace.ts
@@ -4,7 +4,7 @@ export default {
   id: 'attr-whitespace',
   description:
     'All attributes should be separated by only one space and not have leading/trailing whitespace.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const exceptions: Array<string | boolean> = Array.isArray(options)
       ? options
       : []
@@ -24,7 +24,7 @@ export default {
 
         // Check first and last characters for spaces
         if (elem.value.trim() !== elem.value) {
-          reporter.error(
+          reportMessageCallback(
             `The attributes of [ ${attrName} ] must not have trailing whitespace.`,
             event.line,
             col + attr.index,
@@ -34,7 +34,7 @@ export default {
         }
 
         if (elem.value.replace(/ +(?= )/g, '') !== elem.value) {
-          reporter.error(
+          reportMessageCallback(
             `The attributes of [ ${attrName} ] must be separated by only one space.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/attr-whitespace.ts
+++ b/src/core/rules/attr-whitespace.ts
@@ -4,10 +4,8 @@ export default {
   id: 'attr-whitespace',
   description:
     'All attributes should be separated by only one space and not have leading/trailing whitespace.',
-  init(parser, reportMessageCallback, options) {
-    const exceptions: Array<string | boolean> = Array.isArray(options)
-      ? options
-      : []
+  init(parser, reportMessageCallback, options?: { exceptions: string[] }) {
+    const exceptions: string[] = options?.exceptions ?? []
 
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs

--- a/src/core/rules/doctype-first.ts
+++ b/src/core/rules/doctype-first.ts
@@ -4,7 +4,7 @@ import { Rule } from '../types'
 export default {
   id: 'doctype-first',
   description: 'Doctype must be declared first.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const allEvent: Listener = (event) => {
       if (
         event.type === 'start' ||
@@ -17,7 +17,7 @@ export default {
         (event.type !== 'comment' && event.long === false) ||
         /^DOCTYPE\s+/i.test(event.content) === false
       ) {
-        reporter.error(
+        reportMessageCallback(
           'Doctype must be declared first.',
           event.line,
           event.col,

--- a/src/core/rules/doctype-html5.ts
+++ b/src/core/rules/doctype-html5.ts
@@ -4,13 +4,13 @@ import { Rule } from '../types'
 export default {
   id: 'doctype-html5',
   description: 'Invalid doctype. Use: "<!DOCTYPE html>"',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const onComment: Listener = (event) => {
       if (
         event.long === false &&
         event.content.toLowerCase() !== 'doctype html'
       ) {
-        reporter.warn(
+        reportMessageCallback(
           'Invalid doctype. Use: "<!DOCTYPE html>"',
           event.line,
           event.col,

--- a/src/core/rules/head-script-disabled.ts
+++ b/src/core/rules/head-script-disabled.ts
@@ -4,7 +4,7 @@ import { Rule } from '../types'
 export default {
   id: 'head-script-disabled',
   description: 'The <script> tag cannot be used in a <head> tag.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const reScript = /^(text\/javascript|application\/javascript)$/i
     let isInHead = false
 
@@ -22,7 +22,7 @@ export default {
         tagName === 'script' &&
         (!type || reScript.test(type) === true)
       ) {
-        reporter.warn(
+        reportMessageCallback(
           'The <script> tag cannot be used in a <head> tag.',
           event.line,
           event.col,

--- a/src/core/rules/href-abs-or-rel.ts
+++ b/src/core/rules/href-abs-or-rel.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'href-abs-or-rel',
   description: 'An href attribute must be either absolute or relative.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const hrefMode = options === 'abs' ? 'absolute' : 'relative'
 
     parser.addListener('tagstart', (event) => {
@@ -20,7 +20,7 @@ export default {
             (hrefMode === 'relative' &&
               /^https?:\/\//.test(attr.value) === true)
           ) {
-            reporter.warn(
+            reportMessageCallback(
               `The value of the href attribute [ ${attr.value} ] must be ${hrefMode}.`,
               event.line,
               col + attr.index,

--- a/src/core/rules/href-abs-or-rel.ts
+++ b/src/core/rules/href-abs-or-rel.ts
@@ -3,8 +3,12 @@ import { Rule } from '../types'
 export default {
   id: 'href-abs-or-rel',
   description: 'An href attribute must be either absolute or relative.',
-  init(parser, reportMessageCallback, options) {
-    const hrefMode = options === 'abs' ? 'absolute' : 'relative'
+  init(
+    parser,
+    reportMessageCallback,
+    options?: { mode: 'absolute' | 'relative' }
+  ) {
+    const hrefMode = options?.mode ?? 'absolute'
 
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs

--- a/src/core/rules/id-class-ad-disabled.ts
+++ b/src/core/rules/id-class-ad-disabled.ts
@@ -4,7 +4,7 @@ export default {
   id: 'id-class-ad-disabled',
   description:
     'The id and class attributes cannot use the ad keyword, it will be blocked by adblock software.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -17,7 +17,7 @@ export default {
 
         if (/^(id|class)$/i.test(attrName)) {
           if (/(^|[-_])ad([-_]|$)/i.test(attr.value)) {
-            reporter.warn(
+            reportMessageCallback(
               `The value of attribute ${attrName} cannot use the ad keyword.`,
               event.line,
               col + attr.index,

--- a/src/core/rules/id-class-value.ts
+++ b/src/core/rules/id-class-value.ts
@@ -4,7 +4,7 @@ export default {
   id: 'id-class-value',
   description:
     'The id and class attribute values must meet the specified rules.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const arrRules: { [option: string]: { regId: RegExp; message: string } } = {
       underline: {
         regId: /^[a-z\d]+(_[a-z\d]+)*$/,
@@ -48,7 +48,7 @@ export default {
 
           if (attr.name.toLowerCase() === 'id') {
             if (regId.test(attr.value) === false) {
-              reporter.warn(
+              reportMessageCallback(
                 message,
                 event.line,
                 col + attr.index,
@@ -65,7 +65,7 @@ export default {
             for (let j = 0, l2 = arrClass.length; j < l2; j++) {
               classValue = arrClass[j]
               if (classValue && regId.test(classValue) === false) {
-                reporter.warn(
+                reportMessageCallback(
                   message,
                   event.line,
                   col + attr.index,

--- a/src/core/rules/id-class-value.ts
+++ b/src/core/rules/id-class-value.ts
@@ -4,8 +4,14 @@ export default {
   id: 'id-class-value',
   description:
     'The id and class attribute values must meet the specified rules.',
-  init(parser, reportMessageCallback, options) {
-    const arrRules: { [option: string]: { regId: RegExp; message: string } } = {
+  init(
+    parser,
+    reportMessageCallback,
+    options?:
+      | { mode: 'underline' | 'dash' | 'hump' }
+      | { regId: RegExp; message: string }
+  ) {
+    const arrRules = {
       underline: {
         regId: /^[a-z\d]+(_[a-z\d]+)*$/,
         message:
@@ -21,13 +27,16 @@ export default {
         message:
           'The id and class attribute values must meet the camelCase style.',
       },
-    }
-    let rule: { regId: RegExp; message: string } | boolean
+    } as const
 
-    if (typeof options === 'string') {
-      rule = arrRules[options]
-    } else {
-      rule = options as { regId: RegExp; message: string }
+    let rule: { regId: RegExp; message: string } = arrRules.dash
+
+    if (typeof options === 'object') {
+      if ('mode' in options) {
+        rule = arrRules[options.mode]
+      } else {
+        rule = options
+      }
     }
 
     if (typeof rule === 'object' && rule.regId) {

--- a/src/core/rules/id-unique.ts
+++ b/src/core/rules/id-unique.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'id-unique',
   description: 'The value of id attributes must be unique.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const mapIdCount: { [id: string]: number } = {}
 
     parser.addListener('tagstart', (event) => {
@@ -26,7 +26,7 @@ export default {
             }
 
             if (mapIdCount[id] > 1) {
-              reporter.error(
+              reportMessageCallback(
                 `The id value [ ${id} ] must be unique.`,
                 event.line,
                 col + attr.index,

--- a/src/core/rules/inline-script-disabled.ts
+++ b/src/core/rules/inline-script-disabled.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'inline-script-disabled',
   description: 'Inline script cannot be used.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -16,7 +16,7 @@ export default {
         attrName = attr.name.toLowerCase()
 
         if (reEvent.test(attrName) === true) {
-          reporter.warn(
+          reportMessageCallback(
             `Inline script [ ${attr.raw} ] cannot be used.`,
             event.line,
             col + attr.index,
@@ -25,7 +25,7 @@ export default {
           )
         } else if (attrName === 'src' || attrName === 'href') {
           if (/^\s*javascript:/i.test(attr.value)) {
-            reporter.warn(
+            reportMessageCallback(
               `Inline script [ ${attr.raw} ] cannot be used.`,
               event.line,
               col + attr.index,

--- a/src/core/rules/inline-style-disabled.ts
+++ b/src/core/rules/inline-style-disabled.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'inline-style-disabled',
   description: 'Inline style cannot be used.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const attrs = event.attrs
       let attr
@@ -13,7 +13,7 @@ export default {
         attr = attrs[i]
 
         if (attr.name.toLowerCase() === 'style') {
-          reporter.warn(
+          reportMessageCallback(
             `Inline style [ ${attr.raw} ] cannot be used.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/input-requires-label.ts
+++ b/src/core/rules/input-requires-label.ts
@@ -4,7 +4,7 @@ import { Rule } from '../types'
 export default {
   id: 'input-requires-label',
   description: 'All [ input ] tags must have a corresponding [ label ] tag. ',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const labelTags: Array<{
       event: Block
       col: number
@@ -31,7 +31,7 @@ export default {
     parser.addListener('end', () => {
       inputTags.forEach((inputTag) => {
         if (!hasMatchingLabelTag(inputTag)) {
-          reporter.warn(
+          reportMessageCallback(
             'No matching [ label ] tag found.',
             inputTag.event.line,
             inputTag.col,

--- a/src/core/rules/script-disabled.ts
+++ b/src/core/rules/script-disabled.ts
@@ -3,10 +3,10 @@ import { Rule } from '../types'
 export default {
   id: 'script-disabled',
   description: 'The <script> tag cannot be used.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'script') {
-        reporter.error(
+        reportMessageCallback(
           'The <script> tag cannot be used.',
           event.line,
           event.col,

--- a/src/core/rules/space-tab-mixed-disabled.ts
+++ b/src/core/rules/space-tab-mixed-disabled.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'space-tab-mixed-disabled',
   description: 'Do not mix tabs and spaces for indentation.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     let indentMode = 'nomix'
     let spaceLengthRequire: number | '' | null = null
 
@@ -33,7 +33,7 @@ export default {
               /^ +$/.test(whiteSpace) === false ||
               whiteSpace.length % spaceLengthRequire !== 0
             ) {
-              reporter.warn(
+              reportMessageCallback(
                 `Please use space for indentation and keep ${spaceLengthRequire} length.`,
                 fixedPos.line,
                 1,
@@ -43,7 +43,7 @@ export default {
             }
           } else {
             if (/^ +$/.test(whiteSpace) === false) {
-              reporter.warn(
+              reportMessageCallback(
                 'Please use space for indentation.',
                 fixedPos.line,
                 1,
@@ -53,7 +53,7 @@ export default {
             }
           }
         } else if (indentMode === 'tab' && /^\t+$/.test(whiteSpace) === false) {
-          reporter.warn(
+          reportMessageCallback(
             'Please use tab for indentation.',
             fixedPos.line,
             1,
@@ -61,7 +61,7 @@ export default {
             event.raw
           )
         } else if (/ +\t|\t+ /.test(whiteSpace) === true) {
-          reporter.warn(
+          reportMessageCallback(
             'Do not mix tabs and spaces for indentation.',
             fixedPos.line,
             1,

--- a/src/core/rules/space-tab-mixed-disabled.ts
+++ b/src/core/rules/space-tab-mixed-disabled.ts
@@ -3,15 +3,19 @@ import { Rule } from '../types'
 export default {
   id: 'space-tab-mixed-disabled',
   description: 'Do not mix tabs and spaces for indentation.',
-  init(parser, reportMessageCallback, options) {
-    let indentMode = 'nomix'
-    let spaceLengthRequire: number | '' | null = null
+  init(
+    parser,
+    reportMessageCallback,
+    options?: { mode: 'tab' } | { mode: 'space'; size?: number } | undefined
+  ) {
+    const indentMode: 'tab' | 'space' | 'nomix' = options?.mode ?? 'nomix'
+    const defaultSize = 4
+    let spaceLengthRequire: number | null =
+      options?.mode === 'space' ? options?.size ?? defaultSize : null
 
-    if (typeof options === 'string') {
-      const match = /^([a-z]+)(\d+)?/.exec(options)
-      if (match) {
-        indentMode = match[1]
-        spaceLengthRequire = match[2] && parseInt(match[2], 10)
+    if (typeof spaceLengthRequire === 'number') {
+      if (spaceLengthRequire <= 0 || spaceLengthRequire > 8) {
+        spaceLengthRequire = defaultSize
       }
     }
 

--- a/src/core/rules/spec-char-escape.ts
+++ b/src/core/rules/spec-char-escape.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'spec-char-escape',
   description: 'Special characters must be escaped.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('text', (event) => {
       const raw = event.raw
       // TODO: improve use-cases for &
@@ -12,7 +12,7 @@ export default {
 
       while ((match = reSpecChar.exec(raw))) {
         const fixedPos = parser.fixPos(event, match.index)
-        reporter.error(
+        reportMessageCallback(
           `Special characters must be escaped : [ ${match[0]} ].`,
           fixedPos.line,
           fixedPos.col,

--- a/src/core/rules/src-not-empty.ts
+++ b/src/core/rules/src-not-empty.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'src-not-empty',
   description: 'The src attribute of an img(script,link) must have a value.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       const tagName = event.tagName
       const attrs = event.attrs
@@ -20,7 +20,7 @@ export default {
             (tagName === 'object' && attr.name === 'data')) &&
           attr.value === ''
         ) {
-          reporter.error(
+          reportMessageCallback(
             `The attribute [ ${attr.name} ] of the tag [ ${tagName} ] must have a value.`,
             event.line,
             col + attr.index,

--- a/src/core/rules/style-disabled.ts
+++ b/src/core/rules/style-disabled.ts
@@ -3,10 +3,10 @@ import { Rule } from '../types'
 export default {
   id: 'style-disabled',
   description: '<style> tags cannot be used.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     parser.addListener('tagstart', (event) => {
       if (event.tagName.toLowerCase() === 'style') {
-        reporter.warn(
+        reportMessageCallback(
           'The <style> tag cannot be used.',
           event.line,
           event.col,

--- a/src/core/rules/tag-pair.ts
+++ b/src/core/rules/tag-pair.ts
@@ -4,7 +4,7 @@ import { Rule } from '../types'
 export default {
   id: 'tag-pair',
   description: 'Tag must be paired.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const stack: Array<Partial<Block>> = []
     const mapEmptyTags = parser.makeMap(
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
@@ -40,7 +40,7 @@ export default {
 
         if (arrTags.length > 0) {
           const lastEvent = stack[stack.length - 1]
-          reporter.error(
+          reportMessageCallback(
             `Tag must be paired, missing: [ ${arrTags.join(
               ''
             )} ], start tag match failed [ ${lastEvent.raw} ] on line ${
@@ -54,7 +54,7 @@ export default {
         }
         stack.length = pos
       } else {
-        reporter.error(
+        reportMessageCallback(
           `Tag must be paired, no start tag: [ ${event.raw} ]`,
           event.line,
           event.col,
@@ -73,7 +73,7 @@ export default {
 
       if (arrTags.length > 0) {
         const lastEvent = stack[stack.length - 1]
-        reporter.error(
+        reportMessageCallback(
           `Tag must be paired, missing: [ ${arrTags.join(
             ''
           )} ], open tag match failed [ ${lastEvent.raw} ] on line ${

--- a/src/core/rules/tag-self-close.ts
+++ b/src/core/rules/tag-self-close.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'tag-self-close',
   description: 'Empty tags must be self closed.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const mapEmptyTags = parser.makeMap(
       'area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed,track,command,source,keygen,wbr'
     ) //HTML 4.01 + HTML 5
@@ -12,7 +12,7 @@ export default {
       const tagName = event.tagName.toLowerCase()
       if (mapEmptyTags[tagName] !== undefined) {
         if (!event.close) {
-          reporter.warn(
+          reportMessageCallback(
             `The empty tag : [ ${tagName} ] must be self closed.`,
             event.line,
             event.col,

--- a/src/core/rules/tagname-lowercase.ts
+++ b/src/core/rules/tagname-lowercase.ts
@@ -3,7 +3,7 @@ import { Rule } from '../types'
 export default {
   id: 'tagname-lowercase',
   description: 'All html element names must be in lowercase.',
-  init(parser, reporter, options) {
+  init(parser, reportMessageCallback, options) {
     const exceptions: Array<string | boolean> = Array.isArray(options)
       ? options
       : []
@@ -14,7 +14,7 @@ export default {
         exceptions.indexOf(tagName) === -1 &&
         tagName !== tagName.toLowerCase()
       ) {
-        reporter.error(
+        reportMessageCallback(
           `The html element name of [ ${tagName} ] must be in lowercase.`,
           event.line,
           event.col,

--- a/src/core/rules/tagname-lowercase.ts
+++ b/src/core/rules/tagname-lowercase.ts
@@ -3,10 +3,8 @@ import { Rule } from '../types'
 export default {
   id: 'tagname-lowercase',
   description: 'All html element names must be in lowercase.',
-  init(parser, reportMessageCallback, options) {
-    const exceptions: Array<string | boolean> = Array.isArray(options)
-      ? options
-      : []
+  init(parser, reportMessageCallback, options?: { exceptions: string[] }) {
+    const exceptions: string[] = options?.exceptions ?? []
 
     parser.addListener('tagstart,tagend', (event) => {
       const tagName = event.tagName

--- a/src/core/rules/tagname-specialchars.ts
+++ b/src/core/rules/tagname-specialchars.ts
@@ -3,13 +3,13 @@ import { Rule } from '../types'
 export default {
   id: 'tagname-specialchars',
   description: 'All html element names must be in lowercase.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     const specialchars = /[^a-zA-Z0-9\-:_]/
 
     parser.addListener('tagstart,tagend', (event) => {
       const tagName = event.tagName
       if (specialchars.test(tagName)) {
-        reporter.error(
+        reportMessageCallback(
           `The html element name of [ ${tagName} ] contains special character.`,
           event.line,
           event.col,

--- a/src/core/rules/tags-check.ts
+++ b/src/core/rules/tags-check.ts
@@ -32,7 +32,11 @@ let tagsTypings: Record<string, Record<string, unknown>> = {
 export default {
   id: 'tags-check',
   description: 'Checks html tags.',
-  init(parser, reporter, options: Record<string, Record<string, unknown>>) {
+  init(
+    parser,
+    reportMessageCallback,
+    options: Record<string, Record<string, unknown>>
+  ) {
     tagsTypings = { ...tagsTypings, ...options }
 
     parser.addListener('tagstart', (event) => {
@@ -45,7 +49,7 @@ export default {
         const currentTagType = tagsTypings[tagName]
 
         if (currentTagType.selfclosing === true && !event.close) {
-          reporter.warn(
+          reportMessageCallback(
             `The <${tagName}> tag must be selfclosing.`,
             event.line,
             event.col,
@@ -53,7 +57,7 @@ export default {
             event.raw
           )
         } else if (currentTagType.selfclosing === false && event.close) {
-          reporter.warn(
+          reportMessageCallback(
             `The <${tagName}> tag must not be selfclosing.`,
             event.line,
             event.col,
@@ -77,7 +81,7 @@ export default {
                     attr.name === realID &&
                     values.indexOf(attr.value) === -1
                   ) {
-                    reporter.error(
+                    reportMessageCallback(
                       `The <${tagName}> tag must have attr '${realID}' with one value of '${values.join(
                         "' or '"
                       )}'.`,
@@ -89,7 +93,7 @@ export default {
                   }
                 })
               } else {
-                reporter.error(
+                reportMessageCallback(
                   `The <${tagName}> tag must have attr '${realID}'.`,
                   event.line,
                   col,
@@ -100,7 +104,7 @@ export default {
             } else if (
               !attrs.some((attr) => id.split('|').indexOf(attr.name) !== -1)
             ) {
-              reporter.error(
+              reportMessageCallback(
                 `The <${tagName}> tag must have attr '${id}'.`,
                 event.line,
                 col,
@@ -125,7 +129,7 @@ export default {
                     attr.name === realID &&
                     values.indexOf(attr.value) === -1
                   ) {
-                    reporter.error(
+                    reportMessageCallback(
                       `The <${tagName}> tag must have optional attr '${realID}' with one value of '${values.join(
                         "' or '"
                       )}'.`,
@@ -145,7 +149,7 @@ export default {
           const redundantAttrs: string[] = currentTagType.redundantAttrs
           redundantAttrs.forEach((attrName) => {
             if (attrs.some((attr) => attr.name === attrName)) {
-              reporter.error(
+              reportMessageCallback(
                 `The attr '${attrName}' is redundant for <${tagName}> and should be ommited.`,
                 event.line,
                 col,

--- a/src/core/rules/title-require.ts
+++ b/src/core/rules/title-require.ts
@@ -4,7 +4,7 @@ import { Rule } from '../types'
 export default {
   id: 'title-require',
   description: '<title> must be present in <head> tag.',
-  init(parser, reporter) {
+  init(parser, reportMessageCallback) {
     let headBegin = false
     let hasTitle = false
 
@@ -27,7 +27,7 @@ export default {
           lastEvent.type !== 'text' ||
           (lastEvent.type === 'text' && /^\s*$/.test(lastEvent.raw) === true)
         ) {
-          reporter.error(
+          reportMessageCallback(
             '<title></title> must not be empty.',
             event.line,
             event.col,
@@ -37,7 +37,7 @@ export default {
         }
       } else if (tagName === 'head') {
         if (hasTitle === false) {
-          reporter.error(
+          reportMessageCallback(
             '<title> must be present in <head> tag.',
             event.line,
             event.col,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,21 @@ export interface Rule {
 }
 
 export type RuleSeverity = 'off' | 'warn' | 'error'
+
+export function isRuleSeverity(value: unknown): value is RuleSeverity {
+  if (typeof value !== 'string') {
+    return false
+  }
+  switch (value) {
+    case 'off':
+    case 'warn':
+    case 'error':
+      return true
+    default:
+      return false
+  }
+}
+
 export type RuleConfig<Options = Record<string, unknown>> =
   | RuleSeverity
   | [RuleSeverity, Options | undefined]

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,56 +7,61 @@ export interface Rule {
   init(parser: HTMLParser, reporter: Reporter, options: unknown): void
 }
 
-export interface Ruleset {
-  'alt-require'?: boolean
-  'attr-lowercase'?: boolean | Array<string | RegExp>
-  'attr-no-duplication'?: boolean
-  'attr-no-unnecessary-whitespace'?: boolean
-  'attr-sorted'?: boolean
-  'attr-unsafe-chars'?: boolean
-  'attr-value-double-quotes'?: boolean
-  'attr-value-not-empty'?: boolean
-  'attr-value-single-quotes'?: boolean
-  'attr-whitespace'?: boolean
-  'doctype-first'?: boolean
-  'doctype-html5'?: boolean
-  'head-script-disabled'?: boolean
-  'href-abs-or-rel'?: 'abs' | 'rel'
-  'id-class-ad-disabled'?: boolean
-  'id-class-value'?:
-    | 'underline'
-    | 'dash'
-    | 'hump'
-    | { regId: RegExp; message: string }
-  'id-unique'?: boolean
-  'inline-script-disabled'?: boolean
-  'inline-style-disabled'?: boolean
-  'input-requires-label'?: boolean
-  'script-disabled'?: boolean
-  'space-tab-mixed-disabled'?:
-    | boolean
-    | 'space'
-    | 'space1'
-    | 'space2'
-    | 'space3'
-    | 'space4'
-    | 'space5'
-    | 'space6'
-    | 'space7'
-    | 'space8'
-    | 'tab'
-  'spec-char-escape'?: boolean
-  'src-not-empty'?: boolean
-  'style-disabled'?: boolean
-  'tag-pair'?: boolean
-  'tag-self-close'?: boolean
-  'tagname-lowercase'?: boolean
-  'tagname-specialchars'?: boolean
-  'tags-check'?: { [tagName: string]: Record<string, unknown> }
-  'title-require'?: boolean
-  // There may be other unknown rules
-  [ruleId: string]: unknown
+export type RuleSeverity = 'off' | 'warn' | 'error'
+export type RuleConfig<Options = Record<string, unknown>> =
+  | RuleSeverity
+  | [RuleSeverity, Options | undefined]
+
+export interface BaseRuleset {
+  'alt-require'?: RuleConfig<never>
+  'attr-lowercase'?: RuleConfig<{ exceptions: Array<string | RegExp> }>
+  'attr-no-duplication'?: RuleConfig<never>
+  'attr-no-unnecessary-whitespace'?: RuleConfig<never>
+  'attr-sorted'?: RuleConfig<never>
+  'attr-unsafe-chars'?: RuleConfig<never>
+  'attr-value-double-quotes'?: RuleConfig<never>
+  'attr-value-not-empty'?: RuleConfig<never>
+  'attr-value-single-quotes'?: RuleConfig<never>
+  'attr-whitespace'?: RuleConfig<never>
+  'doctype-first'?: RuleConfig<never>
+  'doctype-html5'?: RuleConfig<never>
+  'head-script-disabled'?: RuleConfig<never>
+  'href-abs-or-rel'?: RuleConfig<{ mode: 'absolute' | 'relative' }>
+  'id-class-ad-disabled'?: RuleConfig<never>
+  'id-class-value'?: RuleConfig<{
+    mode: 'underline' | 'dash' | 'hump' | { regId: RegExp; message: string }
+  }>
+  'id-unique'?: RuleConfig<never>
+  'inline-script-disabled'?: RuleConfig<never>
+  'inline-style-disabled'?: RuleConfig<never>
+  'input-requires-label'?: RuleConfig<never>
+  'script-disabled'?: RuleConfig<never>
+  'space-tab-mixed-disabled'?: RuleConfig<
+    { mode: 'tab' } | { mode: 'space'; size?: number }
+  >
+  'spec-char-escape'?: RuleConfig<never>
+  'src-not-empty'?: RuleConfig<never>
+  'style-disabled'?: RuleConfig<never>
+  'tag-pair'?: RuleConfig<never>
+  'tag-self-close'?: RuleConfig<never>
+  'tagname-lowercase'?: RuleConfig<never>
+  'tagname-specialchars'?: RuleConfig<never>
+  'tags-check'?: RuleConfig<{
+    [tagName: string]: {
+      selfclosing?: boolean
+      redundantAttrs?: string[]
+      attrsRequired?: string[]
+      attrsOptional?: string[][]
+    }
+  }>
+  'title-require'?: RuleConfig<never>
 }
+
+export interface CustomRuleset {
+  [ruleId: string]: RuleConfig<unknown>
+}
+
+export type Ruleset = BaseRuleset & CustomRuleset
 
 export const enum ReportType {
   error = 'error',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,21 +21,21 @@ export interface BaseRuleset {
   'alt-require'?: RuleConfig<never>
   'attr-lowercase'?: RuleConfig<{ exceptions: Array<string | RegExp> }>
   'attr-no-duplication'?: RuleConfig<never>
-  'attr-no-unnecessary-whitespace'?: RuleConfig<never>
+  'attr-no-unnecessary-whitespace'?: RuleConfig<{ exceptions: string[] }>
   'attr-sorted'?: RuleConfig<never>
   'attr-unsafe-chars'?: RuleConfig<never>
   'attr-value-double-quotes'?: RuleConfig<never>
   'attr-value-not-empty'?: RuleConfig<never>
   'attr-value-single-quotes'?: RuleConfig<never>
-  'attr-whitespace'?: RuleConfig<never>
+  'attr-whitespace'?: RuleConfig<{ exceptions: string[] }>
   'doctype-first'?: RuleConfig<never>
   'doctype-html5'?: RuleConfig<never>
   'head-script-disabled'?: RuleConfig<never>
   'href-abs-or-rel'?: RuleConfig<{ mode: 'absolute' | 'relative' }>
   'id-class-ad-disabled'?: RuleConfig<never>
-  'id-class-value'?: RuleConfig<{
-    mode: 'underline' | 'dash' | 'hump' | { regId: RegExp; message: string }
-  }>
+  'id-class-value'?: RuleConfig<
+    { mode: 'underline' | 'dash' | 'hump' } | { regId: RegExp; message: string }
+  >
   'id-unique'?: RuleConfig<never>
   'inline-script-disabled'?: RuleConfig<never>
   'inline-style-disabled'?: RuleConfig<never>
@@ -49,7 +49,7 @@ export interface BaseRuleset {
   'style-disabled'?: RuleConfig<never>
   'tag-pair'?: RuleConfig<never>
   'tag-self-close'?: RuleConfig<never>
-  'tagname-lowercase'?: RuleConfig<never>
+  'tagname-lowercase'?: RuleConfig<{ exceptions: string[] }>
   'tagname-specialchars'?: RuleConfig<never>
   'tags-check'?: RuleConfig<{
     [tagName: string]: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,10 +1,15 @@
-import { HTMLParser, Reporter } from './core'
+import { HTMLParser } from './core'
+import { ReportMessageCallback } from './reporter'
 
 export interface Rule {
   id: string
   description: string
   link?: string
-  init(parser: HTMLParser, reporter: Reporter, options: unknown): void
+  init(
+    parser: HTMLParser,
+    reportMessageCallback: ReportMessageCallback,
+    options: unknown
+  ): void
 }
 
 export type RuleSeverity = 'off' | 'warn' | 'error'

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -24,8 +24,8 @@ describe('Core', () => {
   })
 
   it('Inline ruleset not worked should result in an error', () => {
-    // With value = 'true'
-    let code = '<!-- htmlhint alt-require:true -->\r\n<img src="test.gif" />'
+    // With value = 'error'
+    let code = '<!-- htmlhint alt-require:error -->\r\n<img src="test.gif" />'
     let messages = HTMLHint.verify(code, {
       'alt-require': 'off',
     })
@@ -46,8 +46,8 @@ describe('Core', () => {
     expect(messages[0].line).to.be(2)
     expect(messages[0].col).to.be(5)
 
-    // With value = 'false'
-    code = '<!-- htmlhint alt-require:false -->\r\n<img src="test.gif" />'
+    // With value = 'off'
+    code = '<!-- htmlhint alt-require:off -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
       'alt-require': 'error',
     })

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../dist/htmlhint.js').HTMLHint
 describe('Core', () => {
   it('Set false to rule no effected should result in an error', () => {
     const code = '<img src="test.gif" />'
-    const messages = HTMLHint.verify(code, { 'alt-require': false })
+    const messages = HTMLHint.verify(code, { 'alt-require': 'off' })
     expect(messages.length).to.be(0)
   })
 
@@ -27,7 +27,7 @@ describe('Core', () => {
     // With value = 'true'
     let code = '<!-- htmlhint alt-require:true -->\r\n<img src="test.gif" />'
     let messages = HTMLHint.verify(code, {
-      'alt-require': false,
+      'alt-require': 'off',
     })
 
     expect(messages.length).to.be(1)
@@ -38,7 +38,7 @@ describe('Core', () => {
     // Without value
     code = '<!-- htmlhint alt-require -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': false,
+      'alt-require': 'off',
     })
 
     expect(messages.length).to.be(1)
@@ -49,14 +49,14 @@ describe('Core', () => {
     // With value = 'false'
     code = '<!-- htmlhint alt-require:false -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': true,
+      'alt-require': 'error',
     })
     expect(messages.length).to.be(0)
 
     // Without rule
     code = '<!-- htmlhint -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': false,
+      'alt-require': 'off',
     })
 
     expect(messages.length).to.be(0)
@@ -66,8 +66,8 @@ describe('Core', () => {
     const code =
       'tttttttttttttttttttttttttttttttttttt<div>中文<img src="test.gif" />tttttttttttttttttttttttttttttttttttttttttttttt'
     const messages = HTMLHint.verify(code, {
-      'tag-pair': true,
-      'alt-require': true,
+      'tag-pair': 'error',
+      'alt-require': 'error',
     })
     let arrLogs = HTMLHint.format(messages)
     expect(arrLogs.length).to.be(4)

--- a/test/rules/alt-require.spec.js
+++ b/test/rules/alt-require.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'alt-require'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Img tag have empty alt attribute should not result in an error', () => {

--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-lowercase'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Not all lowercase attr should result in an error', () => {
@@ -35,28 +35,28 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Set is false should not result in an error', () => {
     const code = '<p TEST="abc">'
-    ruleOptions[ruldId] = false
+    ruleOptions[ruldId] = 'off'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list should not result in an error', () => {
     const code = '<p testBox="abc" tttAAA="ccc">'
-    ruleOptions[ruldId] = ['testBox', 'tttAAA']
+    ruleOptions[ruldId] = ['error', { exceptions: ['testBox', 'tttAAA'] }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with RegExp should not result in an error', () => {
     const code = '<p testBox="abc" bind:tapTop="ccc">'
-    ruleOptions[ruldId] = ['testBox', /bind:.*/]
+    ruleOptions[ruldId] = ['error', { exceptions: ['testBox', /bind:.*/] }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with regex string should not result in an error', () => {
     const code = '<p testBox="abc" [ngFor]="ccc">'
-    ruleOptions[ruldId] = ['testBox', '/\\[.*\\]/']
+    ruleOptions[ruldId] = ['error', { exceptions: ['testBox', '/\\[.*\\]/'] }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })

--- a/test/rules/attr-no-duplication.spec.js
+++ b/test/rules/attr-no-duplication.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-no-duplication'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute name been duplication should result in an error', () => {

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-no-unnecessary-whitespace'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute with spaces should result in an error', () => {

--- a/test/rules/attr-sort.spec.js
+++ b/test/rules/attr-sort.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruleId = 'attr-sorted'
 const ruleOptions = {}
 
-ruleOptions[ruleId] = true
+ruleOptions[ruleId] = 'error'
 
 describe(`Rules: ${ruleId}`, () => {
   it('Attribute unsorted tags must result in an error', () => {

--- a/test/rules/attr-unsafe-chars.spec.js
+++ b/test/rules/attr-unsafe-chars.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-unsafe-chars'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value have unsafe chars should result in an error', () => {

--- a/test/rules/attr-value-double-quotes.spec.js
+++ b/test/rules/attr-value-double-quotes.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-value-double-quotes'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value closed by single quotes should result in an error', () => {

--- a/test/rules/attr-value-not-empty.spec.js
+++ b/test/rules/attr-value-not-empty.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-value-not-empty'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value have no value should result in an error', () => {

--- a/test/rules/attr-value-single-quotes.spec.js
+++ b/test/rules/attr-value-single-quotes.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-value-single-quotes'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value closed by double quotes should result in an error', () => {

--- a/test/rules/attr-whitespace.spec.js
+++ b/test/rules/attr-whitespace.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'attr-whitespace'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Double spaces in attributes should result in an error', () => {

--- a/test/rules/doctype-first.spec.js
+++ b/test/rules/doctype-first.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'doctype-first'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Doctype not be first should result in an error', () => {

--- a/test/rules/doctype-html5.spec.js
+++ b/test/rules/doctype-html5.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'doctype-html5'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Doctype not html5 should result in an error', () => {

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'head-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('External script in head should result in an error', () => {

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'head-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = 'error'
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('External script in head should result in an error', () => {

--- a/test/rules/head-script-disabled.spec.js
+++ b/test/rules/head-script-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'head-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('External script in head should result in an error', () => {

--- a/test/rules/href-abs-or-rel.spec.js
+++ b/test/rules/href-abs-or-rel.spec.js
@@ -9,7 +9,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is not absolute with abs mode should result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'abs'
+    ruleOptions[ruldId] = ['error', { mode: 'absolute' }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
@@ -23,7 +23,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is absolute with abs mode should not result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'abs'
+    ruleOptions[ruldId] = ['error', { mode: 'absolute' }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
@@ -31,7 +31,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is not relative with rel mode should result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'rel'
+    ruleOptions[ruldId] = ['error', { mode: 'relative' }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
@@ -45,7 +45,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is relative with rel mode should not result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'rel'
+    ruleOptions[ruldId] = ['error', { mode: 'relative' }]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })

--- a/test/rules/id-class-ad-disabled.spec.js
+++ b/test/rules/id-class-ad-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'id-class-ad-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Id use ad keyword should result in an error', () => {

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -8,13 +8,16 @@ const ruleOptionsDash = {}
 const ruleOptionsHump = {}
 const ruleOptionsReg = {}
 
-ruleOptionsUnderline[ruldId] = 'underline'
-ruleOptionsDash[ruldId] = 'dash'
-ruleOptionsHump[ruldId] = 'hump'
-ruleOptionsReg[ruldId] = {
-  regId: /^_[a-z\d]+(-[a-z\d]+)*$/,
-  message: 'Id and class value must meet regexp',
-}
+ruleOptionsUnderline[ruldId] = ['warn', { mode: 'underline' }]
+ruleOptionsDash[ruldId] = ['error', { mdoe: 'dash' }]
+ruleOptionsHump[ruldId] = ['error', { mode: 'hump' }]
+ruleOptionsReg[ruldId] = [
+  'error',
+  {
+    regId: /^_[a-z\d]+(-[a-z\d]+)*$/,
+    message: 'Id and class value must meet regexp',
+  },
+]
 
 describe(`Rules: ${ruldId}`, () => {
   it('Id and class value be not lower case and split by underline should result in an error', () => {
@@ -39,7 +42,9 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class value be not lower case and split by dash should result in an error', () => {
     const code = '<div id="aaaBBB" class="ccc_ddd">'
-    const messages = HTMLHint.verify(code, { 'id-class-value': 'dash' })
+    const messages = HTMLHint.verify(code, {
+      'id-class-value': ['error', 'dash'],
+    })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be('id-class-value')
     expect(messages[0].line).to.be(1)

--- a/test/rules/id-unique.spec.js
+++ b/test/rules/id-unique.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'id-unique'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Id redefine should result in an error', () => {

--- a/test/rules/inline-script-disabled.spec.js
+++ b/test/rules/inline-script-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'inline-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Inline on event should result in an error', () => {

--- a/test/rules/inline-style-disabled.spec.js
+++ b/test/rules/inline-style-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'inline-style-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Inline style should result in an error', () => {

--- a/test/rules/input-requires-label.spec.js
+++ b/test/rules/input-requires-label.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruleId = 'input-requires-label'
 const ruleOptions = {}
 
-ruleOptions[ruleId] = true
+ruleOptions[ruleId] = 'warn'
 
 describe(`Rules: ${ruleId}`, () => {
   describe('Successful cases', () => {

--- a/test/rules/script-disabled.spec.js
+++ b/test/rules/script-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Add external script file should result in an error', () => {

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -9,11 +9,11 @@ const ruleSpace4Options = {}
 const ruleSpace5Options = {}
 const ruleTabOptions = {}
 
-ruleMixOptions[ruldId] = true
-ruleSpaceOptions[ruldId] = 'space'
-ruleSpace4Options[ruldId] = 'space4'
-ruleSpace5Options[ruldId] = 'space5'
-ruleTabOptions[ruldId] = 'tab'
+ruleMixOptions[ruldId] = 'error'
+ruleSpaceOptions[ruldId] = ['error', { mode: 'space' }]
+ruleSpace4Options[ruldId] = ['error', { mode: 'space', size: 4 }]
+ruleSpace5Options[ruldId] = ['error', { mode: 'space', size: 5 }]
+ruleTabOptions[ruldId] = ['error', { mode: 'tab' }]
 
 describe(`Rules: ${ruldId}`, () => {
   it('Spaces and tabs mixed in front of line should result in an error', () => {

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'spec-char-escape'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Special characters: <> should result in an error', () => {

--- a/test/rules/src-not-empty.spec.js
+++ b/test/rules/src-not-empty.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'src-not-empty'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Src be emtpy should result in an error', () => {

--- a/test/rules/style-disabled.spec.js
+++ b/test/rules/style-disabled.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'style-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Style tag should result in an error', () => {

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'tag-pair'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('No end tag should result in an error', () => {

--- a/test/rules/tag-self-close.spec.js
+++ b/test/rules/tag-self-close.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'tag-self-close'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'warn'
 
 describe(`Rules: ${ruldId}`, () => {
   it('The empty tag no closed should result in an error', () => {

--- a/test/rules/tagname-lowercase.spec.js
+++ b/test/rules/tagname-lowercase.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'tagname-lowercase'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('The tag name not all lower case should result in an error', () => {

--- a/test/rules/tagname-specialchars.spec.js
+++ b/test/rules/tagname-specialchars.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'tagname-specialchars'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('Special character in tag name should result in an error', () => {

--- a/test/rules/tags-check.spec.js
+++ b/test/rules/tags-check.spec.js
@@ -5,12 +5,15 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'tags-check'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = {
-  sometag: {
-    selfclosing: true,
-    attrsRequired: [['attrname', 'attrvalue']],
+ruleOptions[ruldId] = [
+  'error',
+  {
+    sometag: {
+      selfclosing: true,
+      attrsRequired: [['attrname', 'attrvalue']],
+    },
   },
-}
+]
 
 describe(`Rules: ${ruldId}`, () => {
   it('Tag <a> should have requered attrs [title, href]', () => {

--- a/test/rules/title-require.spec.js
+++ b/test/rules/title-require.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 const ruldId = 'title-require'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruldId] = 'error'
 
 describe(`Rules: ${ruldId}`, () => {
   it('<title> be present in <head> tag should not result in an error', () => {


### PR DESCRIPTION
BREAKING CHANGE: Rules have a new structure

***Short description of what this resolves:***

ref #279 

***Proposed changes:***

https://github.com/htmlhint/HTMLHint/issues/279#issuecomment-417939741

***Tasks:***

- [ ] "extends": ["htmlhint:recommended"]
- [ ] "defaultSeverity": "error"
- [ ] "htmlVersion": "html5"
- [x] "rules": {/*...*/} (currently not in it's own property)
- [ ] "exclude": ["test/**/*.html"]

I think I will build the other tasks in other PRs