### PR TITLE
docs: Fix attr-value-double-quotes violation example

### DIFF
--- a/docs/user-guide/rules/attr-value-double-quotes.md
+++ b/docs/user-guide/rules/attr-value-double-quotes.md
@@ -23,5 +23,5 @@ The following pattern is considered violation:
 
 <!-- prettier-ignore -->
 ```html
-<a href="" title="abc"></a>
+<a href='' title='abc'></a>
 ```


### PR DESCRIPTION
***Short description of what this resolves:***
The violation example was valid before. This makes it invalid.
