### PR TITLE
feat: move rules into dedicated attribute

### DIFF
--- a/src/cli/htmlhint.ts
+++ b/src/cli/htmlhint.ts
@@ -465,7 +465,7 @@ function hintFile(filepath: string, ruleset?: Ruleset) {
     // ignore
   }
 
-  return HTMLHint.verify(content, ruleset)
+  return HTMLHint.verify(content, { rules: ruleset })
 }
 
 // hint stdin
@@ -483,7 +483,7 @@ function hintStdin(
 
   process.stdin.on('end', () => {
     const content = buffers.join('')
-    const messages = HTMLHint.verify(content, ruleset)
+    const messages = HTMLHint.verify(content, { rules: ruleset })
     callback(messages)
   })
 }
@@ -496,7 +496,7 @@ function hintUrl(
 ) {
   request.get(url, (error, response, body) => {
     if (!error && response.statusCode == 200) {
-      const messages = HTMLHint.verify(body, ruleset)
+      const messages = HTMLHint.verify(body, { rules: ruleset })
       callback(messages)
     } else {
       callback([])

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -1,7 +1,14 @@
 import HTMLParser from './htmlparser'
 import Reporter, { ReportMessageCallback } from './reporter'
 import * as HTMLRules from './rules'
-import { Hint, isRuleSeverity, Rule, Ruleset, RuleSeverity } from './types'
+import {
+  Configuration,
+  Hint,
+  isRuleSeverity,
+  Rule,
+  Ruleset,
+  RuleSeverity,
+} from './types'
 
 export interface FormatOptions {
   colors?: boolean
@@ -27,7 +34,11 @@ class HTMLHintCore {
     this.rules[rule.id] = rule
   }
 
-  public verify(html: string, ruleset: Ruleset = this.defaultRuleset) {
+  public verify(
+    html: string,
+    config: Configuration = { rules: this.defaultRuleset }
+  ) {
+    let ruleset = config.rules ?? this.defaultRuleset
     if (Object.keys(ruleset).length === 0) {
       ruleset = this.defaultRuleset
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,10 @@
 import { HTMLParser } from './core'
 import { ReportMessageCallback } from './reporter'
 
+export interface Configuration {
+  rules?: Ruleset
+}
+
 export interface Rule {
   id: string
   description: string

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -5,7 +5,7 @@ const HTMLHint = require('../dist/htmlhint.js').HTMLHint
 describe('Core', () => {
   it('Set false to rule no effected should result in an error', () => {
     const code = '<img src="test.gif" />'
-    const messages = HTMLHint.verify(code, { 'alt-require': 'off' })
+    const messages = HTMLHint.verify(code, { rules: { 'alt-require': 'off' } })
     expect(messages.length).to.be(0)
   })
 
@@ -27,7 +27,9 @@ describe('Core', () => {
     // With value = 'error'
     let code = '<!-- htmlhint alt-require:error -->\r\n<img src="test.gif" />'
     let messages = HTMLHint.verify(code, {
-      'alt-require': 'off',
+      rules: {
+        'alt-require': 'off',
+      },
     })
 
     expect(messages.length).to.be(1)
@@ -38,7 +40,9 @@ describe('Core', () => {
     // Without value
     code = '<!-- htmlhint alt-require -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': 'off',
+      rules: {
+        'alt-require': 'off',
+      },
     })
 
     expect(messages.length).to.be(1)
@@ -49,14 +53,18 @@ describe('Core', () => {
     // With value = 'off'
     code = '<!-- htmlhint alt-require:off -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': 'error',
+      rules: {
+        'alt-require': 'error',
+      },
     })
     expect(messages.length).to.be(0)
 
     // Without rule
     code = '<!-- htmlhint -->\r\n<img src="test.gif" />'
     messages = HTMLHint.verify(code, {
-      'alt-require': 'off',
+      rules: {
+        'alt-require': 'off',
+      },
     })
 
     expect(messages.length).to.be(0)
@@ -66,8 +74,10 @@ describe('Core', () => {
     const code =
       'tttttttttttttttttttttttttttttttttttt<div>中文<img src="test.gif" />tttttttttttttttttttttttttttttttttttttttttttttt'
     const messages = HTMLHint.verify(code, {
-      'tag-pair': 'error',
-      'alt-require': 'error',
+      rules: {
+        'tag-pair': 'error',
+        'alt-require': 'error',
+      },
     })
     let arrLogs = HTMLHint.format(messages)
     expect(arrLogs.length).to.be(4)

--- a/test/rules/alt-require.spec.js
+++ b/test/rules/alt-require.spec.js
@@ -10,19 +10,19 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('Img tag have empty alt attribute should not result in an error', () => {
     const code = '<img width="200" height="300" alt="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Img tag have non empty alt attribute should not result in an error', () => {
     const code = '<img width="200" height="300" alt="test">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Img tag have not alt attribute should result in an error', () => {
     const code = '<img width="200" height="300">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -33,19 +33,19 @@ describe(`Rules: ${ruldId}`, () => {
   /* A tag can have shape and coords attributes and not have alt attribute */
   it('A tag have not alt attribute should not result in an error', () => {
     const code = '<a>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Area tag have not href and alt attributes should not result in an error', () => {
     const code = '<area>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Area[href] tag have not alt attribute should result in an error', () => {
     const code = '<area href="#test">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -55,7 +55,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Area[href] tag have empty alt attribute should result in an error', () => {
     const code = '<area href="#test" alt="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -65,25 +65,25 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Area[href] tag have non emtpy alt attribute should not result in an error', () => {
     const code = '<area href="#test" alt="test">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Input tag have not type and alt attributes should not result in an error', () => {
     const code = '<input>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Input[type="text"] tag have not alt attribute should not result in an error', () => {
     const code = '<input type="text">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Input[type="image"] tag have not alt attribute should result in an error', () => {
     const code = '<input type="image">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -93,7 +93,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Input[type="image"] tag have empty alt attribute should result in an error', () => {
     const code = '<input type="image" alt="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -103,7 +103,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Input[type="image"] tag have non emtpy alt attribute should not result in an error', () => {
     const code = '<input type="image" alt="test">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -10,14 +10,14 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Not all lowercase attr should result in an error', () => {
     let code = '<p TEST="abc">'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
 
     code = '<p id=""\r\n TEST1="abc" TEST2="abc">'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(2)
@@ -29,35 +29,35 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Lowercase attr should not result in an error', () => {
     const code = '<p test="abc">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Set is false should not result in an error', () => {
     const code = '<p TEST="abc">'
     ruleOptions[ruldId] = 'off'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list should not result in an error', () => {
     const code = '<p testBox="abc" tttAAA="ccc">'
     ruleOptions[ruldId] = ['error', { exceptions: ['testBox', 'tttAAA'] }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with RegExp should not result in an error', () => {
     const code = '<p testBox="abc" bind:tapTop="ccc">'
     ruleOptions[ruldId] = ['error', { exceptions: ['testBox', /bind:.*/] }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with regex string should not result in an error', () => {
     const code = '<p testBox="abc" [ngFor]="ccc">'
     ruleOptions[ruldId] = ['error', { exceptions: ['testBox', '/\\[.*\\]/'] }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-no-duplication.spec.js
+++ b/test/rules/attr-no-duplication.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute name been duplication should result in an error', () => {
     const code = '<a href="a" href="b">bbb</a>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -19,7 +19,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Attribute name not been duplication should not result in an error', () => {
     const code = '<a href="a">bbb</a>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -15,7 +15,7 @@ describe(`Rules: ${ruldId}`, () => {
       '<div title ="a" />',
     ]
     for (let i = 0; i < codes.length; i++) {
-      const messages = HTMLHint.verify(codes[i], ruleOptions)
+      const messages = HTMLHint.verify(codes[i], { rules: ruleOptions })
       expect(messages.length).to.be(1)
       expect(messages[0].rule.id).to.be(ruldId)
       expect(messages[0].line).to.be(1)
@@ -26,7 +26,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Attribute without spaces should not result in an error', () => {
     const codes = ['<div title="a" />', '<div title="a = a" />']
     for (let i = 0; i < codes.length; i++) {
-      const messages = HTMLHint.verify(codes[i], ruleOptions)
+      const messages = HTMLHint.verify(codes[i], { rules: ruleOptions })
       expect(messages.length).to.be(0)
     }
   })

--- a/test/rules/attr-sort.spec.js
+++ b/test/rules/attr-sort.spec.js
@@ -11,7 +11,7 @@ describe(`Rules: ${ruleId}`, () => {
   it('Attribute unsorted tags must result in an error', () => {
     const code = '<div id="test" class="class" title="tite"></div>'
 
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
 
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruleId)
@@ -21,7 +21,7 @@ describe(`Rules: ${ruleId}`, () => {
   it('Attribute unsorted tags that are unrecognizable should not throw error', () => {
     const code = '<div img="image" meta="meta" font="font"></div>'
 
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
 
     expect(messages.length).to.be(0)
   })
@@ -29,7 +29,7 @@ describe(`Rules: ${ruleId}`, () => {
   it('Attribute unsorted of tags of various types should throw error', () => {
     const code = '<div type="type" img="image" id="id" font="font"></div>'
 
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
 
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruleId)

--- a/test/rules/attr-unsafe-chars.spec.js
+++ b/test/rules/attr-unsafe-chars.spec.js
@@ -11,7 +11,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Attribute value have unsafe chars should result in an error', () => {
     const code =
       '<a href="https://vimeo.com/album/1951235/video/56931059‎">Sud Web 2012</a>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -21,14 +21,14 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Attribute value have no unsafe chars should not result in an error', () => {
     const code = '<input disabled="disabled" />'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Attribute value have \\r\\n\\t should not result in an error', () => {
     const code =
       '<link rel="icon" type="image/x-icon" href="data:image/x-icon;base64,R0lGODlhEAAQAKEAAAAAAICAgP///wAAACH/\nC05FVFNDQVBFMi4wAwEAAAAh/hFDcmVhdGVkIHdpdGggR0lNUAAh+QQBZAADACwAAAAAEAAQAAACJIyPacLtvp5kEUwYmL00i81VXK\neNgjiioQdeqsuakXl6tIIjBQAh+QQBZAADACwAAAAAEAAQAAACIIyPacLtvp5kcb5qG85iZ2+BkyiRV8BBaEqtrKkqslEAADs=\t"/>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-value-double-quotes.spec.js
+++ b/test/rules/attr-value-double-quotes.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value closed by single quotes should result in an error', () => {
     const code = "<a href='abc' title=abc style=''>"
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(3)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -25,7 +25,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Attribute value no closed should not result in an error', () => {
     const code = '<input type="button" disabled style="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-value-not-empty.spec.js
+++ b/test/rules/attr-value-not-empty.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value have no value should result in an error', () => {
     const code = '<input disabled>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,13 +20,13 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Attribute value closed by quote but no value should not result in an error', () => {
     const code = '<input disabled="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Attribute value closed by quote and have value should not result in an error', () => {
     const code = '<input disabled="disabled">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-value-single-quotes.spec.js
+++ b/test/rules/attr-value-single-quotes.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Attribute value closed by double quotes should result in an error', () => {
     const code = '<a href="abc" title=abc style="">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(3)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -25,7 +25,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Attribute value no closed should not result in an error', () => {
     const code = "<input type='button' disabled style=''>"
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/attr-whitespace.spec.js
+++ b/test/rules/attr-whitespace.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Double spaces in attributes should result in an error', () => {
     const code = '<p test="test  test1">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Leading/trailing white space should result in an error', () => {
     const code = '<p test=" testtest1 ">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -26,7 +26,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Double spaces and leading/trailing white space should result in an error', () => {
     const code = '<p test=" test  test1 ">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)

--- a/test/rules/doctype-first.spec.js
+++ b/test/rules/doctype-first.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Doctype not be first should result in an error', () => {
     const code = '<html></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -19,7 +19,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Doctype be first should not result in an error', () => {
     const code = '<!DOCTYPE HTML><html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/doctype-html5.spec.js
+++ b/test/rules/doctype-html5.spec.js
@@ -11,7 +11,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Doctype not html5 should result in an error', () => {
     const code =
       '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd"><html></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -21,7 +21,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Doctype html5 should not result in an error', () => {
     const code = '<!DOCTYPE HTML><html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,40 +20,40 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Internal Script in head should result in an error', () => {
     let code = '<head><script>alert(1);</script></head>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     code = '<head><script type="text/javascript">console.log(1)</script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     code =
       '<head><script type="application/javascript">console.log(2)</script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 
   it('Script in body not result in an error', () => {
     const code = '<head></head><body><script src="test.js"></script></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Template script in head not result in an error', () => {
     let code =
       '<head><script type="text/template"><img src="test.png" /></script></head>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
     code =
       '<head><script type="text/ng-template"><img src="test.png" /></script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('No head not result in an error', () => {
     const code = '<html><script src="test.js"></script></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/head-script-disabled.spec.js
+++ b/test/rules/head-script-disabled.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,40 +20,40 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Internal Script in head should result in an error', () => {
     let code = '<head><script>alert(1);</script></head>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     code = '<head><script type="text/javascript">console.log(1)</script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     code =
       '<head><script type="application/javascript">console.log(2)</script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 
   it('Script in body not result in an error', () => {
     const code = '<head></head><body><script src="test.js"></script></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Template script in head not result in an error', () => {
     let code =
       '<head><script type="text/template"><img src="test.png" /></script></head>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
     code =
       '<head><script type="text/ng-template"><img src="test.png" /></script></head>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('No head not result in an error', () => {
     const code = '<html><script src="test.js"></script></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/href-abs-or-rel.spec.js
+++ b/test/rules/href-abs-or-rel.spec.js
@@ -10,7 +10,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = ['error', { mode: 'absolute' }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -24,7 +24,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = ['error', { mode: 'absolute' }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
@@ -32,7 +32,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = ['error', { mode: 'relative' }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -46,7 +46,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
     ruleOptions[ruldId] = ['error', { mode: 'relative' }]
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/id-class-ad-disabled.spec.js
+++ b/test/rules/id-class-ad-disabled.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('Id use ad keyword should result in an error', () => {
     let code = '<div id="ad">test</div>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].type).to.be('warning')
     expect(messages[0].rule.id).to.be(ruldId)
@@ -18,42 +18,42 @@ describe(`Rules: ${ruldId}`, () => {
     expect(messages[0].col).to.be(5)
 
     code = '<div id="ad-222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="ad_222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111-ad">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111_ad">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111-ad-222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111_ad_222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -62,49 +62,49 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Class use ad keyword should result in an error', () => {
     let code = '<div class="ad">test</div>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="ad-222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="ad_222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111-ad">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111_ad">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111-ad-222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111_ad_222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -113,15 +113,15 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class no ad keyword used should not result in an error', () => {
     let code = '<div id="ad1" class="ad2">test</div>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
 
     code = '<div id="ad1-222" class="ad2-222">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
 
     code = '<div id="111-ad1" class="111-ad2">test</div>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -22,7 +22,7 @@ ruleOptionsReg[ruldId] = [
 describe(`Rules: ${ruldId}`, () => {
   it('Id and class value be not lower case and split by underline should result in an error', () => {
     const code = '<div id="aaaBBB" class="ccc-ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsUnderline)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsUnderline })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be('id-class-value')
     expect(messages[0].line).to.be(1)
@@ -36,14 +36,16 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class value be lower case and split by underline should not result in an error', () => {
     const code = '<div id="aaa_bbb" class="ccc_ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsUnderline)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsUnderline })
     expect(messages.length).to.be(0)
   })
 
   it('Id and class value be not lower case and split by dash should result in an error', () => {
     const code = '<div id="aaaBBB" class="ccc_ddd">'
     const messages = HTMLHint.verify(code, {
-      'id-class-value': ['error', 'dash'],
+      rules: {
+        'id-class-value': ['error', 'dash'],
+      },
     })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be('id-class-value')
@@ -56,13 +58,13 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class value be lower case and split by dash should not result in an error', () => {
     const code = '<div id="aaa-bbb" class="ccc-ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsDash)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsDash })
     expect(messages.length).to.be(0)
   })
 
   it('Id and class value be not meet hump style should result in an error', () => {
     const code = '<div id="aaa_bb" class="ccc-ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsHump)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsHump })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be('id-class-value')
     expect(messages[0].line).to.be(1)
@@ -74,13 +76,13 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class value be meet hump style should not result in an error', () => {
     const code = '<div id="aaaBbb" class="cccDdd">'
-    const messages = HTMLHint.verify(code, ruleOptionsHump)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsHump })
     expect(messages.length).to.be(0)
   })
 
   it('Id and class value be not meet regexp should result in an error', () => {
     const code = '<div id="aa-bb" class="ccc-ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsReg)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsReg })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be('id-class-value')
     expect(messages[0].line).to.be(1)
@@ -92,7 +94,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id and class value be meet regexp should not result in an error', () => {
     const code = '<div id="_aaa-bb" class="_ccc-ddd">'
-    const messages = HTMLHint.verify(code, ruleOptionsReg)
+    const messages = HTMLHint.verify(code, { rules: ruleOptionsReg })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/id-unique.spec.js
+++ b/test/rules/id-unique.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Id redefine should result in an error', () => {
     const code = '<div id="test"></div><div id="test"></div>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Id no redefine should not result in an error', () => {
     const code = '<div id="test1"></div><div id="test2"></div>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/inline-script-disabled.spec.js
+++ b/test/rules/inline-script-disabled.spec.js
@@ -11,7 +11,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Inline on event should result in an error', () => {
     const code =
       '<body><img src="test.gif" onclick="alert(1);"><img src="test.gif" onMouseDown="alert(1);"></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -22,14 +22,14 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('onttt should not result in an error', () => {
     const code = '<body><img src="test.gif" onttt="alert(1);"></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Javascript protocol [ javascript: ] should result in an error', () => {
     let code =
       '<body><img src="javascript:alert(1)"><img src=" JAVASCRIPT:alert(1)"></body>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -39,7 +39,7 @@ describe(`Rules: ${ruldId}`, () => {
 
     code =
       '<body><a href="javascript:alert(1)">test1</a><a href=" JAVASCRIPT:alert(2)">test2</a></body>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)

--- a/test/rules/inline-style-disabled.spec.js
+++ b/test/rules/inline-style-disabled.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('Inline style should result in an error', () => {
     let code = '<body><div style="color:red;"></div></body>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -18,7 +18,7 @@ describe(`Rules: ${ruldId}`, () => {
     expect(messages[0].type).to.be('warning')
 
     code = '<body><div STYLE="color:red;"></div></body>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 })

--- a/test/rules/input-requires-label.spec.js
+++ b/test/rules/input-requires-label.spec.js
@@ -12,14 +12,14 @@ describe(`Rules: ${ruleId}`, () => {
     it('Input tag with a matching label before should result in no error', () => {
       const code =
         '<label for="some-id"/><input id="some-id" type="password" />'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(0)
     })
 
     it('Input tag with a matching label after should result in no error', () => {
       const code =
         '<input id="some-id" type="password" /> <label for="some-id"/>'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(0)
     })
   })
@@ -27,7 +27,7 @@ describe(`Rules: ${ruleId}`, () => {
   describe('Error cases', () => {
     it('Input tag with no matching label should result in an error', () => {
       const code = '<input type="password">'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(1)
       expect(messages[0].rule.id).to.be(ruleId)
       expect(messages[0].line).to.be(1)
@@ -38,7 +38,7 @@ describe(`Rules: ${ruleId}`, () => {
     it("Input tag with label that doesn't match id should result in error", () => {
       const code =
         '<input id="some-id" type="password" /> <label for="some-other-id"/>'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(1)
       expect(messages[0].rule.id).to.be(ruleId)
       expect(messages[0].line).to.be(1)
@@ -48,7 +48,7 @@ describe(`Rules: ${ruleId}`, () => {
 
     it('Input tag with blank label:for should result in error', () => {
       const code = '<input id="some-id" type="password" /> <label for=""/>'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(1)
       expect(messages[0].rule.id).to.be(ruleId)
       expect(messages[0].line).to.be(1)
@@ -58,7 +58,7 @@ describe(`Rules: ${ruleId}`, () => {
 
     it('Input tag with no id should result in error', () => {
       const code = '<input type="password" /> <label for="something"/>'
-      const messages = HTMLHint.verify(code, ruleOptions)
+      const messages = HTMLHint.verify(code, { rules: ruleOptions })
       expect(messages.length).to.be(1)
       expect(messages[0].rule.id).to.be(ruleId)
       expect(messages[0].line).to.be(1)

--- a/test/rules/script-disabled.spec.js
+++ b/test/rules/script-disabled.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Add external script file should result in an error', () => {
     const code = '<body><script src="test.js"></script></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -19,7 +19,7 @@ describe(`Rules: ${ruldId}`, () => {
   })
   it('Add inline script should result in an error', () => {
     const code = '<body><script>var test = "test";</script></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -19,21 +19,21 @@ describe(`Rules: ${ruldId}`, () => {
   it('Spaces and tabs mixed in front of line should result in an error', () => {
     // space before tab
     let code = '    	<a href="a">      bbb</a>'
-    let messages = HTMLHint.verify(code, ruleMixOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     // tab before space
     code = '		 <a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleMixOptions)
+    messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     // multi line
     code = '<div>\r\n	 <a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleMixOptions)
+    messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(2)
@@ -42,40 +42,40 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Only spaces in front of line should not result in an error', () => {
     let code = '     <a href="a">      bbb</a>'
-    let messages = HTMLHint.verify(code, ruleMixOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(0)
 
     code = '<div>\r\n     <a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleMixOptions)
+    messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Only tabs in front of line should not result in an error', () => {
     const code = '			<a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleMixOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleMixOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Not only space in front of line should result in an error', () => {
     // mixed 1
     let code = '    	<a href="a">      bbb</a>'
-    let messages = HTMLHint.verify(code, ruleSpaceOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleSpaceOptions })
     expect(messages.length).to.be(1)
 
     // mixed 2
     code = '	    <a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleSpaceOptions)
+    messages = HTMLHint.verify(code, { rules: ruleSpaceOptions })
     expect(messages.length).to.be(1)
 
     // only tab
     code = '		<a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleSpaceOptions)
+    messages = HTMLHint.verify(code, { rules: ruleSpaceOptions })
     expect(messages.length).to.be(1)
   })
 
   it('Not only space and 4 length in front of line should result in an error', () => {
     const code = '     <a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleSpace4Options)
+    const messages = HTMLHint.verify(code, { rules: ruleSpace4Options })
     expect(messages.length).to.be(1)
     expect(messages[0].message).to.be(
       'Please use space for indentation and keep 4 length.'
@@ -84,13 +84,13 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Only space and 4 length in front of line should not result in an error', () => {
     const code = '        <a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleSpace4Options)
+    const messages = HTMLHint.verify(code, { rules: ruleSpace4Options })
     expect(messages.length).to.be(0)
   })
 
   it('Not only space and 5 length in front of line should result in an error', () => {
     const code = '      <a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleSpace5Options)
+    const messages = HTMLHint.verify(code, { rules: ruleSpace5Options })
     expect(messages.length).to.be(1)
     expect(messages[0].message).to.be(
       'Please use space for indentation and keep 5 length.'
@@ -99,37 +99,37 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Only space and 5 length in front of line should not result in an error', () => {
     const code = '          <a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleSpace5Options)
+    const messages = HTMLHint.verify(code, { rules: ruleSpace5Options })
     expect(messages.length).to.be(0)
   })
 
   it('Only space in front of line should not result in an error', () => {
     const code = '            <a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleSpaceOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleSpaceOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Not only tab in front of line should result in an error', () => {
     // mixed 1
     let code = '	    <a href="a">      bbb</a>'
-    let messages = HTMLHint.verify(code, ruleTabOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleTabOptions })
     expect(messages.length).to.be(1)
 
     // mixed 2
     code = '    	<a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleTabOptions)
+    messages = HTMLHint.verify(code, { rules: ruleTabOptions })
     expect(messages.length).to.be(1)
 
     // only space
     code = '       <a href="a">      bbb</a>'
-    messages = HTMLHint.verify(code, ruleTabOptions)
+    messages = HTMLHint.verify(code, { rules: ruleTabOptions })
     expect(messages.length).to.be(1)
   })
 
   it('Only tab in front of line should not result in an error', () => {
     // only tab
     const code = '		<a href="a">      bbb</a>'
-    const messages = HTMLHint.verify(code, ruleTabOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleTabOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Special characters: <> should result in an error', () => {
     const code = '<p>aaa>bbb< ccc</p>ddd\r\neee<'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(3)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -25,7 +25,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Special characters: & should result in an error', () => {
     const code = '<p>Steinway & Sons</p>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -34,13 +34,13 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Normal text should not result in an error', () => {
     const code = '<p>abc</p>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Properly formed HTML entities should not result in an error', () => {
     const code = '<p>Steinway &amp; &gt; Sons Q&amp;A </p>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/src-not-empty.spec.js
+++ b/test/rules/src-not-empty.spec.js
@@ -11,21 +11,21 @@ describe(`Rules: ${ruldId}`, () => {
   it('Src be emtpy should result in an error', () => {
     const code =
       '<img src="" /><img src /><script src=""></script><script src></script><link href="" type="text/css" /><link href type="text/css" /><embed src=""><embed src><bgsound src="" /><bgsound src /><iframe src=""><iframe src><object data=""><object data>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(14)
   })
 
   it('Src be non-empty should not result in an error', () => {
     const code =
       '<img src="test.png" /><script src="test.js"></script><link href="test.css" type="text/css" /><embed src="test.swf"><bgsound src="test.mid" /><iframe src="test.html"><object data="test.swf">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('Src be not set value should not result in an error', () => {
     const code =
       '<img width="200" /><script></script><link type="text/css" /><embed width="200"><bgsound /><iframe width="200"><object width="200">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/style-disabled.spec.js
+++ b/test/rules/style-disabled.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('Style tag should result in an error', () => {
     const code = '<body><style>body{}</style></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Stylesheet link should not result in an error', () => {
     const code = '<body><link rel="stylesheet" href="test.css" /></body>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('No end tag should result in an error', () => {
     let code = '<ul><li></ul><span>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, () => {
     expect(messages[1].col).to.be(20)
 
     code = '<div></div>\r\n<div>aaa'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(2)
     expect(messages[0].col).to.be(9)
@@ -28,7 +28,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('No start tag should result in an error', () => {
     const code = '</div>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -37,7 +37,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Tag be paired should not result in an error', () => {
     const code = '<p>aaa</p>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/tag-self-close.spec.js
+++ b/test/rules/tag-self-close.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'warn'
 describe(`Rules: ${ruldId}`, () => {
   it('The empty tag no closed should result in an error', () => {
     const code = '<br><img src="test.jpg">'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -25,7 +25,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Closed empty tag should not result in an error', () => {
     const code = '<br /><img src="a.jpg"/>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/tagname-lowercase.spec.js
+++ b/test/rules/tagname-lowercase.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('The tag name not all lower case should result in an error', () => {
     const code = '<A href=""></A><SPAN>aab</spaN>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(4)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -28,7 +28,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('All lower case tag name should not result in an error', () => {
     const code = '<a href=""></a><span>test</span>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/tagname-specialchars.spec.js
+++ b/test/rules/tagname-specialchars.spec.js
@@ -10,7 +10,7 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('Special character in tag name should result in an error', () => {
     const code = '<@ href="link"></@><$pan>aab</$pan>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[0].line).to.be(1)
@@ -22,7 +22,7 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Tag name without special character should not result in an error', () => {
     const code = '<a href=""></a><span>test</span>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 })

--- a/test/rules/tags-check.spec.js
+++ b/test/rules/tags-check.spec.js
@@ -18,48 +18,48 @@ ruleOptions[ruldId] = [
 describe(`Rules: ${ruldId}`, () => {
   it('Tag <a> should have requered attrs [title, href]', () => {
     const code = '<a>blabla</a>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[1].rule.id).to.be(ruldId)
   })
   it('Tag <a> should not be selfclosing', () => {
     const code = '<a href="bbb" title="aaa"/>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
   it('Tag <img> should be selfclosing', () => {
     const code = '<img src="bbb" title="aaa" alt="asd"></img>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
   it('Should check optional attributes', () => {
     const code = '<script src="aaa" async="sad" />'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
     expect(messages[0].rule.id).to.be(ruldId)
   })
   it('Should check redunant attributes', () => {
     const code = '<main role="main" />'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
     expect(messages[1].rule.id).to.be(ruldId)
   })
   it('Should be extendable trought config', () => {
     const code = '<sometag></sometag>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(2)
     expect(messages[0].rule.id).to.be(ruldId)
   })
   it('Should check required attributes with specifyed values', () => {
     let code = '<sometag attrname="attrvalue" />'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
     code = '<sometag attrname="wrong_value" />'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 })

--- a/test/rules/title-require.spec.js
+++ b/test/rules/title-require.spec.js
@@ -10,37 +10,37 @@ ruleOptions[ruldId] = 'error'
 describe(`Rules: ${ruldId}`, () => {
   it('<title> be present in <head> tag should not result in an error', () => {
     const code = '<html><head><title>test</title></head><body></body></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('<title> not be present in <head> tag should result in an error', () => {
     let code = '<html><head></head><body></body></html>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
 
     code = '<html><head></head><body><title>test</title></body></html>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
 
     code = '<html><title>test</title><head></head><body></body></html>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 
   it('No head should not result in an error', () => {
     const code = '<html><body></body></html>'
-    const messages = HTMLHint.verify(code, ruleOptions)
+    const messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(0)
   })
 
   it('<title></title> is empty should result in an error', () => {
     let code = '<html><head><title></title></head><body></body></html>'
-    let messages = HTMLHint.verify(code, ruleOptions)
+    let messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
 
     code = '<html><head><title>  \t   </title></head><body></body></html>'
-    messages = HTMLHint.verify(code, ruleOptions)
+    messages = HTMLHint.verify(code, { rules: ruleOptions })
     expect(messages.length).to.be(1)
   })
 })


### PR DESCRIPTION
***Short description of what this resolves:***

We want to support a new configuration structure that can handle more than just the rules
So we have to move the rules to a dedicated `rules` attribute

***Proposed changes:***

- Move rules into dedicated attribute "rules": { /* ... */ }