### PR TITLE
docs: Change CSS to HTML in getting started example description 

### DIFF
--- a/docs/user-guide/getting-started.mdx
+++ b/docs/user-guide/getting-started.mdx
@@ -42,7 +42,7 @@ yarn add --dev htmlhint
 }
 ```
 
-3\. Run HTMLHint on, for example, all the CSS files in your project:
+3\. Run HTMLHint on, for example, all the HTML files in your project:
 
 ```shell
 npx htmlhint "**/*.html"


### PR DESCRIPTION
***Short description of what this resolves:***
I noticed a small error in the getting started docs, where it shows how to run HTML Hint on all html files in the project, but the description said CSS files. 

***Proposed changes:***

Change CSS to HTML