### PR TITLE
docs(user.guide): add input-requires-label

### DIFF
--- a/docs/user-guide/list-rules.md
+++ b/docs/user-guide/list-rules.md
@@ -22,6 +22,7 @@ title: List of rules
 - [`attr-value-double-quotes`](/docs/user-guide/rules/attr-value-double-quotes): Attribute values must be in double quotes.
 - [`attr-value-not-empty`](/docs/user-guide/rules/attr-not-empty): All attributes must have values.
 - [`alt-require`](/docs/user-guide/rules/alt-require): The alt attribute of an element must be present and alt attribute of area[href] and input[type=image] must have a value.
+- [`input-requires-label`](/docs/user-guide/rules/input-requires-label): All [ input ] tags must have a corresponding [ label ] tag.
 
 ### Tags
 

--- a/docs/user-guide/rules/input-requires-label.md
+++ b/docs/user-guide/rules/input-requires-label.md
@@ -1,0 +1,35 @@
+---
+id: input-requires-label
+title: input-requires-label
+keywords:
+  - input
+  - label
+  - accessiblity
+---
+
+All [ input ] tags must have a corresponding [ label ] tag.
+
+Level: warning
+
+## Config value
+
+1. true: enable rule
+2. false: disable rule
+
+The following pattern are **not** considered violations:
+
+<!-- prettier-ignore -->
+```html
+<input type="password">
+<input id="some-id" type="password" /> <label for="some-other-id"/>
+<input id="some-id" type="password" /> <label for=""/>
+<input type="password" /> <label for="something"/>
+```
+
+The following pattern is considered violation:
+
+<!-- prettier-ignore -->
+```html
+<label for="some-id"/><input id="some-id" type="password" />
+<input id="some-id" type="password" /> <label for="some-id"/>
+```


### PR DESCRIPTION
Hi :wave:!

According to the following rule ` input-requires-label` introduce in [`v0.13.0`](https://github.com/htmlhint/HTMLHint/blob/master/CHANGELOG.md#0130-2020-05-18), I'm submitting this Pull Request in order to update the documentation.

## :memo: Documentation

Added into the following section **Attributes** but please let me know if I have to move it into a different section. 

8023f29 - docs(user.guide): add input-requires-label

## :link: Relates

Rules has been introduce here: #159

Hope you'll find this useful.
Thank you :pray:!