### PR TITLE
docs: Changes explanation text to match example

### DIFF
--- a/docs/user-guide/getting-started.mdx
+++ b/docs/user-guide/getting-started.mdx
@@ -42,7 +42,7 @@ yarn add --dev htmlhint
 }
 ```
 
-3\. Run HTMLHint on, for example, all the CSS files in your project:
+3\. Run HTMLHint on, for example, all the HTML files in your project:
 
 ```shell
 npx htmlhint "**/*.html"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -93,7 +93,7 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
-          editUrl: `${GITHUB_URL}/edit/develop/docs/`,
+          editUrl: `${GITHUB_URL}/edit/master/docs/`,
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
***Short description of what this resolves:***
- Fixes example text to say `all the HTML files` instead of `all the CSS files`
- Fixes edit url to not go to a 404 page


P.S. if you don't mind, it would be greatly appreciated if you could also add the `hacktoberfest-accepted` label to this as I am participating in hacktoberfest. If not, I understand and it's no biggie