### PR TITLE
fix: Link to configuration.md from options page

### DIFF
--- a/docs/user-guide/usage/options.md
+++ b/docs/user-guide/usage/options.md
@@ -7,7 +7,7 @@ title: Options
 
 CLI flag: `--config`
 
-Path to a JSON, YAML, or JS file that contains your [configuration object](../configure.md).
+Path to a JSON, YAML, or JS file that contains your [configuration object](../configuration.md).
 
 Use this option if you don't want HTMLHint to search for a configuration file.
 


### PR DESCRIPTION
***Short description of what this resolves:***

Was looking at the docs on https://htmlhint.com/docs/user-guide/usage/options and found the the link was a 404


***Proposed changes:***

Found the right file in the repo https://github.com/htmlhint/HTMLHint/blob/master/docs/user-guide/configuration.md so adjusting the link target
