### PR TITLE
fix: improve documentation of attr-lowercase rule

### DIFF
--- a/docs/user-guide/rules/attr-lowercase.md
+++ b/docs/user-guide/rules/attr-lowercase.md
@@ -11,18 +11,18 @@ Level: `error`
 
 1. true: enable rule
 2. false: disable rule
-3. ['viewBox', 'test']: Ignore some attr name
+3. ['viewBox', 'Test']: enable rule except for the given attribute names
 
-The following pattern are **not** considered violations:
+The following pattern is **not** considered a violation:
 
 <!-- prettier-ignore -->
 ```html
 <img src="test.png" alt="test" />
 ```
 
-The following pattern is considered violation:
+The following pattern is considered a violation:
 
 <!-- prettier-ignore -->
 ```html
-<img src="test.png" alt="test" />
+<img SRC="test.png" ALT="test" />
 ```


### PR DESCRIPTION
The "violation" example was identical to the non-violation one.

Also adjusted wording and capitalization for clarity and correctness.

Fixes #531 (/cc @tag).