### PR TITLE
docs: Add Mega-Linter in list of integrations

### DIFF
--- a/docs/user-guide/integrations/task-runner.md
+++ b/docs/user-guide/integrations/task-runner.md
@@ -10,3 +10,4 @@ Task runner integrations built and maintained by HTMLHint organization and the c
 - [gulp-htmlhint-inline](https://github.com/htmlhint/gulp-htmlhint-inline) - Gulp plugin for linting inline html.
 - [htmlhint-loader](https://github.com/htmlhint/htmlhint-loader) - webpack loader for HTMLHint.
 - [super-linter](https://github.com/github/super-linter) - GitHub action - a combination of linters, including HTMLHint.
+- [mega-linter](https://nvuillam.github.io/mega-linter/) - Aggregates 70+ linters for CI or local run, [including HTMLHint](https://nvuillam.github.io/mega-linter/descriptors/html_htmlhint/)


### PR DESCRIPTION


***Proposed changes:***

Add Mega-Linter in list of integrations
If you have a banner for HTMLHint, please notify me and I'll update [HTMLHint mega-linter page](https://nvuillam.github.io/mega-linter/descriptors/html_htmlhint/) :)