### PR TITLE
fix: Added regex to remove template tags

### DIFF
--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -148,11 +148,11 @@ export default class HTMLParser {
         if ((tagName = match[4])) {
           // Label start
           arrAttrs = []
-          const attrs = match[5]
+          const attrs = match[5].replace(regTemplate,'')
           let attrMatch
           let attrMatchCount = 0
 
-          while ((attrMatch = regAttr.exec(attrs.replace(regTemplate,'')))) {
+          while ((attrMatch = regAttr.exec(attrs))) {
             const name = attrMatch[1]
             const quote = attrMatch[2]
               ? attrMatch[2]

--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -59,6 +59,7 @@ export default class HTMLParser {
     // eslint-disable-next-line no-control-regex
     const regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g
     const regLine = /\r?\n/g
+    const regTemplate = /(\{\%|\{\{).+?(\%\}|\}\})/g
 
     let match: RegExpExecArray | null
     let matchIndex: number
@@ -151,7 +152,7 @@ export default class HTMLParser {
           let attrMatch
           let attrMatchCount = 0
 
-          while ((attrMatch = regAttr.exec(attrs))) {
+          while ((attrMatch = regAttr.exec(attrs.replace(regTemplate,'')))) {
             const name = attrMatch[1]
             const quote = attrMatch[2]
               ? attrMatch[2]

--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -148,7 +148,7 @@ export default class HTMLParser {
         if ((tagName = match[4])) {
           // Label start
           arrAttrs = []
-          const attrs = match[5].replace(regTemplate,'')
+          const attrs = match[5].replace(regTemplate, '')
           let attrMatch
           let attrMatchCount = 0
 

--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -59,7 +59,7 @@ export default class HTMLParser {
     // eslint-disable-next-line no-control-regex
     const regAttr = /\s*([^\s"'>\/=\x00-\x0F\x7F\x80-\x9F]+)(?:\s*=\s*(?:(")([^"]*)"|(')([^']*)'|([^\s"'>]*)))?/g
     const regLine = /\r?\n/g
-    const regTemplate = /(\{\%|\{\{).+?(\%\}|\}\})/g
+    const regTemplate = /\s(\{\%|\{\{).+?(\%\}|\}\})/g
 
     let match: RegExpExecArray | null
     let matchIndex: number


### PR DESCRIPTION
#585 > hopefully this helps to resolve 1/2 of the template tag issues

 
Added regex to remove template tags from attribute list.
for example
```html
<option {% if a == b %}disabled{% endif %}>disabled</option>
```
will no longer throw quote errors, attribute lowercase errors, Attr No Duplication, Attr Must Have A Value and, attr No Unnecessary Whitespace.