### PR TITLE
fix: Put rules in website menu in alphabetical order

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -9,8 +9,8 @@ module.exports = {
           {
             'Individual rules': [
               'user-guide/rules/alt-require',
-              'user-guide/rules/attr-no-duplication',
               'user-guide/rules/attr-lowercase',
+              'user-guide/rules/attr-no-duplication',
               'user-guide/rules/attr-unsafe-chars',
               'user-guide/rules/attr-value-double-quotes',
               'user-guide/rules/attr-value-not-empty',


### PR DESCRIPTION
***Short description of what this resolves:***

Very, very minor nit here, but the current rules [are not in alphabetical order in the menu on the left of the website](https://htmlhint.com/docs/user-guide/rules/alt-require).

![website menu](https://user-images.githubusercontent.com/10931297/106469160-d7017100-6496-11eb-9b58-360e1a932fe2.png)

***Proposed changes:***

Swap `attr-no-duplication` and `attr-lowercase` so they are in order