### PR TITLE
Feat/support angular template validation

### DIFF
--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -80,6 +80,18 @@ export default class HTMLParser {
       col: 1,
     })
 
+    // Do not ignore validation inside <script type="ng/template"> template
+    const isMapCdataTagsRequired = () => {
+      const attrType = arrAttrs.find((attr) => attr.name === 'type') || {
+        value: '',
+      }
+
+      return (
+        mapCdataTags[tagName] &&
+        attrType.value.indexOf('text/ng-template') === -1
+      )
+    }
+
     // Memory block
     const saveBlock = (
       type: string,
@@ -183,7 +195,7 @@ export default class HTMLParser {
               close: match[6],
             })
 
-            if (mapCdataTags[tagName]) {
+            if (isMapCdataTagsRequired()) {
               tagCDATA = tagName
               attrsCDATA = arrAttrs.concat()
               arrCDATA = []

--- a/test/htmlparser.spec.js
+++ b/test/htmlparser.spec.js
@@ -614,6 +614,30 @@ describe('HTMLParser: Case parse', () => {
     parser.parse('<link rel=icon /><link rel=icon />')
   })
 
+  it('should parse special tag inside script template', (done) => {
+    const parser = new HTMLParser()
+    const arrEvents = []
+    getAllEvents(parser, arrEvents, () => {
+      expect(arrEvents[1]).to.event('tagstart', {
+        tagName: 'script',
+      })
+
+      const mapAttrs = parser.getMapAttrs(arrEvents[1].attrs)
+      expect(mapAttrs.type).to.be('text/ng-template')
+
+      expect(arrEvents[2]).to.event('tagstart', {
+        tagName: 'div',
+      })
+
+      expect(arrEvents[3]).to.event('tagend', {
+        tagName: 'script',
+      })
+
+      done()
+    })
+    parser.parse('<script type="text/ng-template"><div></script>')
+  })
+
   it('should parse special empty attr', (done) => {
     const parser = new HTMLParser()
     const arrEvents = []


### PR DESCRIPTION
There is no way to validate html inside angular's template

For example:
```
<html>
......
<script type="text/ng-template">
    <div>Lorem ipsum
</script>
......
</html>
```
will no raise error validation when {'tag-pair': true}

But if I do
```
<html>
......
<div>Lorem ipsum
......
</html>
```
it works