### PR TITLE
docs: remove Brackets mention (deprecated)

### DIFF
--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -6,6 +6,5 @@ title: Editor integrations
 Editor integrations built and maintained by the HTMLHint organization and some by the community.
 
 - [atom-htmlhint](https://github.com/htmlhint/atom-htmlhint) - Atom plugin for HTMLHint.
-- [brackets-htmlhint](https://github.com/htmlhint/brackets-htmlhint) - Brackets wrapper for HTMLHint.
 - [SublimeLinter-contrib-htmlhint](https://github.com/htmlhint/SublimeLinter-contrib-htmlhint) - Sublime Text plugin for HTMLHint.
 - [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=mkaufman.HTMLHint) - VS Code extension for HTMLHint.


### PR DESCRIPTION
***Short description of what this resolves:***

Remove Brackets HTMLHint (IDE deprecated)


