### PR TITLE
fix: `How To Use` link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 </p>
 
 <p align="center">
-  <a href="#installation-and-usage">How To Use</a> • <a href="#contributing">Contributing</a> • <a href="https://htmlhint.com">Website</a>
+  <a href="#-installation-and-usage">How To Use</a> • <a href="#contributing">Contributing</a> • <a href="https://htmlhint.com">Website</a>
 </p>
 
 ## Table of Contents


### PR DESCRIPTION
Fix the broken `How To Use` link on the Readme.

