### PR TITLE
fix: fix the message for `attr-whitespace`

### DIFF
--- a/src/core/rules/attr-whitespace.ts
+++ b/src/core/rules/attr-whitespace.ts
@@ -25,7 +25,7 @@ export default {
         // Check first and last characters for spaces
         if (elem.value.trim() !== elem.value) {
           reporter.error(
-            `The attributes of [ ${attrName} ] must not have trailing whitespace.`,
+            `The attributes of [ ${attrName} ] must not have leading or trailing whitespace.`,
             event.line,
             col + attr.index,
             this,


### PR DESCRIPTION
***Short description of what this resolves:***

Right now the following html ends with the message: "The attributes of [ id ] must not have trailing whitespace."

```html
<a id=" test"></a>
```

It doesn't really make sense since the whitespace is at the start.

***Proposed changes:***

This PR adds the "leading whitespace" possibility to the message.

