### PR TITLE
chore(build): Run matrix on current node releases

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -19,7 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 15]
+        node:
+          - 12
+          - 14
+          - 16
+          - 17
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -18,7 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 15]
+        node:
+          - 12
+          - 14
+          - 16
+          - 17
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
***Short description of what this resolves:***
Node 12, 14, 16, and 17 are the current supported NodeJS versions, so the matrix will excercise them all for regressions

***Proposed changes:***

