### PR TITLE
chore(build): remove redundant matrix

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -15,10 +15,6 @@ on:
 jobs:
   test-release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [14]
-        os: [ubuntu-latest]
 
     steps:
       - name: ⬇️ Checkout repo


### PR DESCRIPTION


***Short description of what this resolves:***
The matrix values weren't being used by the tasks, so it's falling back to the default runner value

***Proposed changes:***

