### PR TITLE
chore(build): add Dependabot for website packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+  - package-ecosystem: npm
+    directory: "/website"
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: "/website/plugins/docusaurus-plugin-hotjar"
+    schedule:
+      interval: weekly
     versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION


***Short description of what this resolves:***
Dependabot currently only runs on the root package.json and not any of the child package.json files. This adds the checks for the website subfolders

***Proposed changes:***

