### PR TITLE
chore: run lint once for CI

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,10 +13,30 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v2
+
+      - name: ⎔ Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
+      - name: 📥 Download deps
+        run: npm ci
+        env:
+          HUSKY_SKIP_INSTALL: true
+
+      - name: 🧪 Run lint
+        run: npm run lint
+
   build:
     # ignore all-contributors PRs
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       matrix:
         node:
@@ -45,9 +65,6 @@ jobs:
         run: npm ci
         env:
           HUSKY_SKIP_INSTALL: true
-
-      - name: 🧪 Run lint
-        run: npm run lint
 
       - name: 🏗 Build
         run: npm run build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,10 +12,30 @@ on:
       - '!all-contributors/**'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@v2
+
+      - name: ⎔ Setup node ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          cache: npm
+
+      - name: 📥 Download deps
+        run: npm ci
+        env:
+          HUSKY_SKIP_INSTALL: true
+
+      - name: 🧪 Run lint
+        run: npm run lint
+
   build:
     # ignore all-contributors PRs
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       matrix:
         node:
@@ -44,9 +64,6 @@ jobs:
         run: npm ci
         env:
           HUSKY_SKIP_INSTALL: true
-
-      - name: 🧪 Run lint
-        run: npm run lint
 
       - name: 🏗 Build
         run: npm run build


### PR DESCRIPTION
***Short description of what this resolves:***
The linting shouldn't matter accross OS versions so pull it up to run once before all the matrix builds are triggered to fail fast

***Proposed changes:***

