### PR TITLE
fix: clenaup non-functional typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://www.npmjs.com/package/htmlhint">
     <img src="https://img.shields.io/npm/dm/htmlhint.svg" alt="NPM count">
   </a>
-  <img src="https://badgen.net/badge/license/MIT/green" alt="MIT Licence" />
+  <img src="https://badgen.net/badge/license/MIT/green" alt="MIT License" />
   <a href="https://discord.gg/nJ6J9CP">
     <img src="https://img.shields.io/badge/chat-on%20discord-7289da.svg" alt="Chat">
   </a>

--- a/docs/user-guide/rules/input-requires-label.md
+++ b/docs/user-guide/rules/input-requires-label.md
@@ -4,7 +4,7 @@ title: input-requires-label
 keywords:
   - input
   - label
-  - accessiblity
+  - accessibility
 ---
 
 All [ input ] tags must have a corresponding [ label ] tag.

--- a/docs/user-guide/rules/src-not-empty.md
+++ b/docs/user-guide/rules/src-not-empty.md
@@ -5,7 +5,7 @@ title: src-not-empty
 
 Src of img(script, link) must set value.
 
-Emtpy of src will visit current page twice.
+Empty of src will visit current page twice.
 
 Level: `error`
 

--- a/src/cli/htmlhint.ts
+++ b/src/cli/htmlhint.ts
@@ -174,7 +174,7 @@ function hintTargets(
   })
 }
 
-// load custom rles
+// load custom rules
 function loadCustomRules(rulesdir: string) {
   rulesdir = rulesdir.replace(/\\/g, '/')
   if (existsSync(rulesdir)) {
@@ -215,7 +215,7 @@ function hintAllFiles(
     formatter: Formatter
     ruleset?: Ruleset
   },
-  onFinised: (result: {
+  onFinished: (result: {
     targetFileCount: number
     targetHintFileCount: number
     targetHintCount: number
@@ -292,7 +292,7 @@ function hintAllFiles(
 
   function checkAllHinted() {
     if (isWalkDone && isHintDone) {
-      onFinised({
+      onFinished({
         targetFileCount: targetFileCount,
         targetHintFileCount: targetHintFileCount,
         targetHintCount: targetHintCount,

--- a/src/core/rules/tags-check.ts
+++ b/src/core/rules/tags-check.ts
@@ -146,7 +146,7 @@ export default {
           redundantAttrs.forEach((attrName) => {
             if (attrs.some((attr) => attr.name === attrName)) {
               reporter.error(
-                `The attr '${attrName}' is redundant for <${tagName}> and should be ommited.`,
+                `The attr '${attrName}' is redundant for <${tagName}> and should be omitted.`,
                 event.line,
                 col,
                 this,

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -62,7 +62,7 @@ describe('Core', () => {
     expect(messages.length).to.be(0)
   })
 
-  it('Show formated result should not result in an error', () => {
+  it('Show formatted result should not result in an error', () => {
     const code =
       'tttttttttttttttttttttttttttttttttttt<div>中文<img src="test.gif" />tttttttttttttttttttttttttttttttttttttttttttttt'
     const messages = HTMLHint.verify(code, {

--- a/test/rules/alt-require.spec.js
+++ b/test/rules/alt-require.spec.js
@@ -2,12 +2,12 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'alt-require'
+const ruleId = 'alt-require'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Img tag have empty alt attribute should not result in an error', () => {
     const code = '<img width="200" height="300" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -24,7 +24,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<img width="200" height="300">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
     expect(messages[0].type).to.be('warning')
@@ -47,7 +47,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<area href="#test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(6)
     expect(messages[0].type).to.be('warning')
@@ -57,13 +57,13 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<area href="#test" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(6)
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Area[href] tag have non emtpy alt attribute should not result in an error', () => {
+  it('Area[href] tag have non empty alt attribute should not result in an error', () => {
     const code = '<area href="#test" alt="test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
@@ -85,7 +85,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<input type="image">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')
@@ -95,13 +95,13 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<input type="image" alt="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')
   })
 
-  it('Input[type="image"] tag have non emtpy alt attribute should not result in an error', () => {
+  it('Input[type="image"] tag have non empty alt attribute should not result in an error', () => {
     const code = '<input type="image" alt="test">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/attr-lowercase.spec.js
+++ b/test/rules/attr-lowercase.spec.js
@@ -2,27 +2,27 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-lowercase'
+const ruleId = 'attr-lowercase'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Not all lowercase attr should result in an error', () => {
     let code = '<p TEST="abc">'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
 
     code = '<p id=""\r\n TEST1="abc" TEST2="abc">'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(2)
     expect(messages[0].col).to.be(1)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(2)
     expect(messages[1].col).to.be(13)
   })
@@ -35,28 +35,28 @@ describe(`Rules: ${ruldId}`, () => {
 
   it('Set is false should not result in an error', () => {
     const code = '<p TEST="abc">'
-    ruleOptions[ruldId] = false
+    ruleOptions[ruleId] = false
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list should not result in an error', () => {
     const code = '<p testBox="abc" tttAAA="ccc">'
-    ruleOptions[ruldId] = ['testBox', 'tttAAA']
+    ruleOptions[ruleId] = ['testBox', 'tttAAA']
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with RegExp should not result in an error', () => {
     const code = '<p testBox="abc" bind:tapTop="ccc">'
-    ruleOptions[ruldId] = ['testBox', /bind:.*/]
+    ruleOptions[ruleId] = ['testBox', /bind:.*/]
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
 
   it('Set to array list with regex string should not result in an error', () => {
     const code = '<p testBox="abc" [ngFor]="ccc">'
-    ruleOptions[ruldId] = ['testBox', '/\\[.*\\]/']
+    ruleOptions[ruleId] = ['testBox', '/\\[.*\\]/']
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })

--- a/test/rules/attr-no-duplication.spec.js
+++ b/test/rules/attr-no-duplication.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-no-duplication'
+const ruleId = 'attr-no-duplication'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute name been duplication should result in an error', () => {
     const code = '<a href="a" href="b">bbb</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(12)
   })

--- a/test/rules/attr-no-unnecessary-whitespace.spec.js
+++ b/test/rules/attr-no-unnecessary-whitespace.spec.js
@@ -2,12 +2,12 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-no-unnecessary-whitespace'
+const ruleId = 'attr-no-unnecessary-whitespace'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute with spaces should result in an error', () => {
     const codes = [
       '<div title = "a" />',
@@ -17,7 +17,7 @@ describe(`Rules: ${ruldId}`, () => {
     for (let i = 0; i < codes.length; i++) {
       const messages = HTMLHint.verify(codes[i], ruleOptions)
       expect(messages.length).to.be(1)
-      expect(messages[0].rule.id).to.be(ruldId)
+      expect(messages[0].rule.id).to.be(ruleId)
       expect(messages[0].line).to.be(1)
       expect(messages[0].col).to.be(5)
     }

--- a/test/rules/attr-sort.spec.js
+++ b/test/rules/attr-sort.spec.js
@@ -9,7 +9,7 @@ ruleOptions[ruleId] = true
 
 describe(`Rules: ${ruleId}`, () => {
   it('Attribute unsorted tags must result in an error', () => {
-    const code = '<div id="test" class="class" title="tite"></div>'
+    const code = '<div id="test" class="class" title="title"></div>'
 
     const messages = HTMLHint.verify(code, ruleOptions)
 

--- a/test/rules/attr-unsafe-chars.spec.js
+++ b/test/rules/attr-unsafe-chars.spec.js
@@ -2,18 +2,18 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-unsafe-chars'
+const ruleId = 'attr-unsafe-chars'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute value have unsafe chars should result in an error', () => {
     const code =
       '<a href="https://vimeo.com/album/1951235/video/56931059‎">Sud Web 2012</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/attr-value-double-quotes.spec.js
+++ b/test/rules/attr-value-double-quotes.spec.js
@@ -2,23 +2,23 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-value-double-quotes'
+const ruleId = 'attr-value-double-quotes'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute value closed by single quotes should result in an error', () => {
     const code = "<a href='abc' title=abc style=''>"
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(14)
-    expect(messages[2].rule.id).to.be(ruldId)
+    expect(messages[2].rule.id).to.be(ruleId)
     expect(messages[2].line).to.be(1)
     expect(messages[2].col).to.be(24)
   })

--- a/test/rules/attr-value-not-empty.spec.js
+++ b/test/rules/attr-value-not-empty.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-value-not-empty'
+const ruleId = 'attr-value-not-empty'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute value have no value should result in an error', () => {
     const code = '<input disabled>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/attr-value-single-quotes.spec.js
+++ b/test/rules/attr-value-single-quotes.spec.js
@@ -2,23 +2,23 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-value-single-quotes'
+const ruleId = 'attr-value-single-quotes'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Attribute value closed by double quotes should result in an error', () => {
     const code = '<a href="abc" title=abc style="">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(14)
-    expect(messages[2].rule.id).to.be(ruldId)
+    expect(messages[2].rule.id).to.be(ruleId)
     expect(messages[2].line).to.be(1)
     expect(messages[2].col).to.be(24)
   })

--- a/test/rules/attr-whitespace.spec.js
+++ b/test/rules/attr-whitespace.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'attr-whitespace'
+const ruleId = 'attr-whitespace'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Double spaces in attributes should result in an error', () => {
     const code = '<p test="test  test1">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
   })
 
@@ -20,7 +20,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<p test=" testtest1 ">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
   })
 
@@ -28,7 +28,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<p test=" test  test1 ">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
   })
 })

--- a/test/rules/doctype-first.spec.js
+++ b/test/rules/doctype-first.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'doctype-first'
+const ruleId = 'doctype-first'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Doctype not be first should result in an error', () => {
     const code = '<html></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
   })

--- a/test/rules/doctype-html5.spec.js
+++ b/test/rules/doctype-html5.spec.js
@@ -2,18 +2,18 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'doctype-html5'
+const ruleId = 'doctype-html5'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Doctype not html5 should result in an error', () => {
     const code =
       '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "https://www.w3.org/TR/html4/strict.dtd"><html></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/empty-tag-not-self-closed.spec.js
+++ b/test/rules/empty-tag-not-self-closed.spec.js
@@ -2,12 +2,12 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'empty-tag-not-self-closed'
+const ruleId = 'empty-tag-not-self-closed'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('The empty tag no closed should not result in an error', () => {
     const code = '<br><img src="test.jpg">'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -18,11 +18,11 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<br /><img src="a.jpg"/>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     expect(messages[0].type).to.be('error')
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(7)
     expect(messages[1].type).to.be('error')

--- a/test/rules/head-require.spec.js
+++ b/test/rules/head-require.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'head-script-disabled'
+const ruleId = 'head-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')
@@ -22,7 +22,7 @@ describe(`Rules: ${ruldId}`, () => {
     let code = '<head><script>alert(1);</script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     code = '<head><script type="text/javascript">console.log(1)</script></head>'

--- a/test/rules/head-script-disabled.spec.js
+++ b/test/rules/head-script-disabled.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'head-script-disabled'
+const ruleId = 'head-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('External script in head should result in an error', () => {
     const code = '<head><script src="test.js"></script></head>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')
@@ -22,7 +22,7 @@ describe(`Rules: ${ruldId}`, () => {
     let code = '<head><script>alert(1);</script></head>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     code = '<head><script type="text/javascript">console.log(1)</script></head>'

--- a/test/rules/href-abs-or-rel.spec.js
+++ b/test/rules/href-abs-or-rel.spec.js
@@ -2,20 +2,20 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'href-abs-or-rel'
+const ruleId = 'href-abs-or-rel'
 const ruleOptions = {}
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Href value is not absolute with abs mode should result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'abs'
+    ruleOptions[ruleId] = 'abs'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(27)
   })
@@ -23,7 +23,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is absolute with abs mode should not result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'abs'
+    ruleOptions[ruleId] = 'abs'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
@@ -31,13 +31,13 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is not relative with rel mode should result in an error', () => {
     const code =
       '<a href="http://www.alibaba.com/">aaa</a><a href="https://www.alibaba.com/">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'rel'
+    ruleOptions[ruleId] = 'rel'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(3)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(44)
   })
@@ -45,7 +45,7 @@ describe(`Rules: ${ruldId}`, () => {
   it('Href value is relative with rel mode should not result in an error', () => {
     const code =
       '<a href="a.html">aaa</a><a href="../b.html">bbb</a><a href="tel:12345678">ccc</a><a href="javascript:void()">ddd</a>'
-    ruleOptions[ruldId] = 'rel'
+    ruleOptions[ruleId] = 'rel'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })

--- a/test/rules/html-lang-require.spec.js
+++ b/test/rules/html-lang-require.spec.js
@@ -2,12 +2,12 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'html-lang-require'
+const ruleId = 'html-lang-require'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('All the rest(non HTML) tags should not result in an error', () => {
     const code = '<html lang="en-EN"><body><p></p></body></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
@@ -28,12 +28,12 @@ describe(`Rules: ${ruldId}`, () => {
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
   })
-  it('HTML tag have an non emtpy and valid(en-EN) lang attribute should not result in an error', () => {
+  it('HTML tag have an non empty and valid(en-EN) lang attribute should not result in an error', () => {
     const code = '<html lang="en-EN"></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)
   })
-  it('HTML tag have an non emtpy and valid(en) lang attribute should not result in an error', () => {
+  it('HTML tag have an non empty and valid(en) lang attribute should not result in an error', () => {
     const code = '<html lang="en"></html>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/id-class-ad-disabled.spec.js
+++ b/test/rules/id-class-ad-disabled.spec.js
@@ -2,60 +2,60 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'id-class-ad-disabled'
+const ruleId = 'id-class-ad-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Id use ad keyword should result in an error', () => {
     let code = '<div id="ad">test</div>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
     expect(messages[0].type).to.be('warning')
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="ad-222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="ad_222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111-ad">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111_ad">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111-ad-222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div id="111_ad_222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
   })
@@ -64,49 +64,49 @@ describe(`Rules: ${ruldId}`, () => {
     let code = '<div class="ad">test</div>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="ad-222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="ad_222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111-ad">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111_ad">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111-ad-222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
 
     code = '<div class="111_ad_222">test</div>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(5)
   })

--- a/test/rules/id-class-value.spec.js
+++ b/test/rules/id-class-value.spec.js
@@ -2,21 +2,21 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'id-class-value'
+const ruleId = 'id-class-value'
 const ruleOptionsUnderline = {}
 const ruleOptionsDash = {}
 const ruleOptionsHump = {}
 const ruleOptionsReg = {}
 
-ruleOptionsUnderline[ruldId] = 'underline'
-ruleOptionsDash[ruldId] = 'dash'
-ruleOptionsHump[ruldId] = 'hump'
-ruleOptionsReg[ruldId] = {
+ruleOptionsUnderline[ruleId] = 'underline'
+ruleOptionsDash[ruleId] = 'dash'
+ruleOptionsHump[ruleId] = 'hump'
+ruleOptionsReg[ruleId] = {
   regId: /^_[a-z\d]+(-[a-z\d]+)*$/,
   message: 'Id and class value must meet regexp',
 }
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Id and class value be not lower case and split by underline should result in an error', () => {
     const code = '<div id="aaaBBB" class="ccc-ddd">'
     const messages = HTMLHint.verify(code, ruleOptionsUnderline)

--- a/test/rules/id-unique.spec.js
+++ b/test/rules/id-unique.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'id-unique'
+const ruleId = 'id-unique'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Id redefine should result in an error', () => {
     const code = '<div id="test"></div><div id="test"></div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(26)
     expect(messages[0].type).to.be('error')

--- a/test/rules/inline-script-disabled.spec.js
+++ b/test/rules/inline-script-disabled.spec.js
@@ -2,18 +2,18 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'inline-script-disabled'
+const ruleId = 'inline-script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Inline on event should result in an error', () => {
     const code =
       '<body><img src="test.gif" onclick="alert(1);"><img src="test.gif" onMouseDown="alert(1);"></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(26)
     expect(messages[0].type).to.be('warning')
@@ -31,7 +31,7 @@ describe(`Rules: ${ruldId}`, () => {
       '<body><img src="javascript:alert(1)"><img src=" JAVASCRIPT:alert(1)"></body>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(11)
     expect(messages[0].type).to.be('warning')
@@ -41,7 +41,7 @@ describe(`Rules: ${ruldId}`, () => {
       '<body><a href="javascript:alert(1)">test1</a><a href=" JAVASCRIPT:alert(2)">test2</a></body>'
     messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(9)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/inline-style-disabled.spec.js
+++ b/test/rules/inline-style-disabled.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'inline-style-disabled'
+const ruleId = 'inline-style-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Inline style should result in an error', () => {
     let code = '<body><div style="color:red;"></div></body>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(11)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/script-disabled.spec.js
+++ b/test/rules/script-disabled.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'script-disabled'
+const ruleId = 'script-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Add external script file should result in an error', () => {
     const code = '<body><script src="test.js"></script></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('error')
@@ -21,7 +21,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<body><script>var test = "test";</script></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('error')

--- a/test/rules/space-tab-mixed-disabled.spec.js
+++ b/test/rules/space-tab-mixed-disabled.spec.js
@@ -2,40 +2,40 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'space-tab-mixed-disabled'
+const ruleId = 'space-tab-mixed-disabled'
 const ruleMixOptions = {}
 const ruleSpaceOptions = {}
 const ruleSpace4Options = {}
 const ruleSpace5Options = {}
 const ruleTabOptions = {}
 
-ruleMixOptions[ruldId] = true
-ruleSpaceOptions[ruldId] = 'space'
-ruleSpace4Options[ruldId] = 'space4'
-ruleSpace5Options[ruldId] = 'space5'
-ruleTabOptions[ruldId] = 'tab'
+ruleMixOptions[ruleId] = true
+ruleSpaceOptions[ruleId] = 'space'
+ruleSpace4Options[ruleId] = 'space4'
+ruleSpace5Options[ruleId] = 'space5'
+ruleTabOptions[ruleId] = 'tab'
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Spaces and tabs mixed in front of line should result in an error', () => {
     // space before tab
     let code = '    	<a href="a">      bbb</a>'
     let messages = HTMLHint.verify(code, ruleMixOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     // tab before space
     code = '		 <a href="a">      bbb</a>'
     messages = HTMLHint.verify(code, ruleMixOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     // multi line
     code = '<div>\r\n	 <a href="a">      bbb</a>'
     messages = HTMLHint.verify(code, ruleMixOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(2)
     expect(messages[0].col).to.be(1)
   })

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -2,23 +2,23 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'spec-char-escape'
+const ruleId = 'spec-char-escape'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Special characters: <> should result in an error', () => {
     const code = '<p>aaa>bbb< ccc</p>ddd\r\neee<'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(3)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(11)
-    expect(messages[2].rule.id).to.be(ruldId)
+    expect(messages[2].rule.id).to.be(ruleId)
     expect(messages[2].line).to.be(2)
     expect(messages[2].col).to.be(4)
   })
@@ -27,7 +27,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '<p>Steinway & Sons</p>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(12)
   })

--- a/test/rules/src-not-empty.spec.js
+++ b/test/rules/src-not-empty.spec.js
@@ -2,13 +2,13 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'src-not-empty'
+const ruleId = 'src-not-empty'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
-  it('Src be emtpy should result in an error', () => {
+describe(`Rules: ${ruleId}`, () => {
+  it('Src be empty should result in an error', () => {
     const code =
       '<img src="" /><img src /><script src=""></script><script src></script><link href="" type="text/css" /><link href type="text/css" /><embed src=""><embed src><bgsound src="" /><bgsound src /><iframe src=""><iframe src><object data=""><object data>'
     const messages = HTMLHint.verify(code, ruleOptions)

--- a/test/rules/style-disabled.spec.js
+++ b/test/rules/style-disabled.spec.js
@@ -2,17 +2,17 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'style-disabled'
+const ruleId = 'style-disabled'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Style tag should result in an error', () => {
     const code = '<body><style>body{}</style></body>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(7)
     expect(messages[0].type).to.be('warning')

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -2,26 +2,26 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'tag-pair'
+const ruleId = 'tag-pair'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('No end tag should result in an error', () => {
     let code = '<ul><li></ul><span>'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(9)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(20)
 
     code = '<div></div>\r\n<div>aaa'
     messages = HTMLHint.verify(code, ruleOptions)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(2)
     expect(messages[0].col).to.be(9)
   })
@@ -30,7 +30,7 @@ describe(`Rules: ${ruldId}`, () => {
     const code = '</div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
   })

--- a/test/rules/tag-self-close.spec.js
+++ b/test/rules/tag-self-close.spec.js
@@ -2,21 +2,21 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'tag-self-close'
+const ruleId = 'tag-self-close'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('The empty tag no closed should result in an error', () => {
     const code = '<br><img src="test.jpg">'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
     expect(messages[0].type).to.be('warning')
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(5)
     expect(messages[1].type).to.be('warning')

--- a/test/rules/tagname-lowercase.spec.js
+++ b/test/rules/tagname-lowercase.spec.js
@@ -2,26 +2,26 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'tagname-lowercase'
+const ruleId = 'tagname-lowercase'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('The tag name not all lower case should result in an error', () => {
     const code = '<A href=""></A><SPAN>aab</spaN>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(4)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(1)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(12)
-    expect(messages[2].rule.id).to.be(ruldId)
+    expect(messages[2].rule.id).to.be(ruleId)
     expect(messages[2].line).to.be(1)
     expect(messages[2].col).to.be(16)
-    expect(messages[3].rule.id).to.be(ruldId)
+    expect(messages[3].rule.id).to.be(ruleId)
     expect(messages[3].line).to.be(1)
     expect(messages[3].col).to.be(25)
   })

--- a/test/rules/tagname-specialchars.spec.js
+++ b/test/rules/tagname-specialchars.spec.js
@@ -2,20 +2,20 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'tagname-specialchars'
+const ruleId = 'tagname-specialchars'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('Special character in tag name should result in an error', () => {
     const code = '<@ href="link"></@><$pan>aab</$pan>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
     expect(messages[0].line).to.be(1)
     expect(messages[0].col).to.be(16)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[1].rule.id).to.be(ruleId)
     expect(messages[1].line).to.be(1)
     expect(messages[1].col).to.be(29)
   })

--- a/test/rules/tags-check.spec.js
+++ b/test/rules/tags-check.spec.js
@@ -2,56 +2,56 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'tags-check'
+const ruleId = 'tags-check'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = {
+ruleOptions[ruleId] = {
   sometag: {
     selfclosing: true,
     attrsRequired: [['attrname', 'attrvalue']],
   },
 }
 
-describe(`Rules: ${ruldId}`, () => {
-  it('Tag <a> should have requered attrs [title, href]', () => {
+describe(`Rules: ${ruleId}`, () => {
+  it('Tag <a> should have required attrs [title, href]', () => {
     const code = '<a>blabla</a>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
+    expect(messages[1].rule.id).to.be(ruleId)
   })
   it('Tag <a> should not be selfclosing', () => {
     const code = '<a href="bbb" title="aaa"/>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
   })
   it('Tag <img> should be selfclosing', () => {
     const code = '<img src="bbb" title="aaa" alt="asd"></img>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
   })
   it('Should check optional attributes', () => {
     const code = '<script src="aaa" async="sad" />'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(1)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
   })
-  it('Should check redunant attributes', () => {
+  it('Should check redundant attributes', () => {
     const code = '<main role="main" />'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
-    expect(messages[1].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
+    expect(messages[1].rule.id).to.be(ruleId)
   })
-  it('Should be extendable trought config', () => {
+  it('Should be extendable through config', () => {
     const code = '<sometag></sometag>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(2)
-    expect(messages[0].rule.id).to.be(ruldId)
+    expect(messages[0].rule.id).to.be(ruleId)
   })
-  it('Should check required attributes with specifyed values', () => {
+  it('Should check required attributes with specified values', () => {
     let code = '<sometag attrname="attrvalue" />'
     let messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).to.be(0)

--- a/test/rules/title-require.spec.js
+++ b/test/rules/title-require.spec.js
@@ -2,12 +2,12 @@ const expect = require('expect.js')
 
 const HTMLHint = require('../../dist/htmlhint.js').HTMLHint
 
-const ruldId = 'title-require'
+const ruleId = 'title-require'
 const ruleOptions = {}
 
-ruleOptions[ruldId] = true
+ruleOptions[ruleId] = true
 
-describe(`Rules: ${ruldId}`, () => {
+describe(`Rules: ${ruleId}`, () => {
   it('<title> be present in <head> tag should not result in an error', () => {
     const code = '<html><head><title>test</title></head><body></body></html>'
     const messages = HTMLHint.verify(code, ruleOptions)


### PR DESCRIPTION
***Short description of what this resolves:***
Took a pass across with cSpell to address some minor typos. Have a local config that could be added later to enforce the checking. There is one breaking typo that I'll submit separately

***Proposed changes:***

