### PR TITLE
chore(release): fix release github

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,34 @@
+{
+  "branches": [
+    "master",
+    { "name": "alpha", "prerelease": true },
+    { "name": "beta", "prerelease": true }
+  ],
+  "repositoryUrl": "https://github.com/htmlhint/HTMLHint",
+  "debug": "true",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/github",
+    "@semantic-release/npm",
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "dist",
+          "bin",
+          "package.json",
+          "package-lock.json",
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -104,16 +104,6 @@
     "semantic-release": "^17.4.7",
     "typescript": "3.9.6"
   },
-  "release": {
-    "plugins": [
-      "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      "@semantic-release/changelog",
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      "@semantic-release/git"
-    ]
-  },
   "files": [
     "bin",
     "dist"


### PR DESCRIPTION
***Short description of what this resolves:***

The release was missing the release github plugin.

Moved configuration to a separated file.

