### PR TITLE
chore: increase Dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,20 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    open-pull-requests-limit: 99
   - package-ecosystem: npm
     directory: '/website'
     schedule:
       interval: weekly
+    open-pull-requests-limit: 99
   - package-ecosystem: npm
     directory: '/website/plugins/docusaurus-plugin-hotjar'
     schedule:
       interval: weekly
     versioning-strategy: increase
+    open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: weekly
+    open-pull-requests-limit: 99


### PR DESCRIPTION


***Short description of what this resolves:***
Default limit is 5, so this will allow more PRs to be open at once. I think there may be less than 5 remaining, but in the future this will allow them to be opened, even if some others get stalled

***Proposed changes:***

