### PR TITLE
chore: unpin remaining devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "@types/async": "^3.2.10",
         "@types/glob": "^7.2.0",
         "@types/node-fetch": "^2.5.12",
-        "@types/parse-glob": "3.0.29",
-        "@types/xml": "1.0.6",
+        "@types/parse-glob": "^3.0.29",
+        "@types/xml": "^1.0.6",
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "commitizen": "^4.2.4",
@@ -44,16 +44,16 @@
         "eslint": "^8.3.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
-        "expect.js": "0.3.1",
+        "expect.js": "^0.3.1",
         "husky": "^7.0.4",
         "lint-staged": "^12.1.2",
         "mocha": "^9.1.3",
-        "nyc": "15.1.0",
+        "nyc": "^15.1.0",
         "prettier": "^2.4.1",
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
         "semantic-release": "^18.0.0",
-        "typescript": "3.9.6"
+        "typescript": "^3.9.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11540,9 +11540,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20700,9 +20700,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "@types/async": "^3.2.10",
     "@types/glob": "^7.2.0",
     "@types/node-fetch": "^2.5.12",
-    "@types/parse-glob": "3.0.29",
-    "@types/xml": "1.0.6",
+    "@types/parse-glob": "^3.0.29",
+    "@types/xml": "^1.0.6",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "commitizen": "^4.2.4",
@@ -104,15 +104,15 @@
     "eslint": "^8.3.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "expect.js": "0.3.1",
+    "expect.js": "^0.3.1",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
     "mocha": "^9.1.3",
-    "nyc": "15.1.0",
+    "nyc": "^15.1.0",
     "prettier": "^2.4.1",
     "rollup": "^2.60.1",
     "rollup-plugin-terser": "^7.0.2",
     "semantic-release": "^18.0.0",
-    "typescript": "3.9.6"
+    "typescript": "^3.9.10"
   }
 }


### PR DESCRIPTION
***Short description of what this resolves:***
Does move Typescript to the latest in the 3 branch, but mostly just moves the devDeps to carret ranges

***Proposed changes:***

