### PR TITLE
chore: downgrade parse-glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "5.1.0",
         "glob": "^7.2.0",
         "node-fetch": "^2.6.2",
-        "parse-glob": "3.0.4",
+        "parse-glob": "^2.0.1",
         "strip-json-comments": "3.1.0",
         "xml": "1.0.1"
       },
@@ -4530,24 +4530,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dependencies": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
+    "node_modules/glob-path-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz",
+      "integrity": "sha1-E4OpjJ7fDv84Dth3qIcqrl6UB50=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dependencies": {
-        "is-glob": "^2.0.0"
       }
     },
     "node_modules/global-dirs": {
@@ -5006,22 +4994,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -5032,12 +5004,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dependencies": {
-        "is-extglob": "^1.0.0"
-      },
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+      "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10009,14 +9978,12 @@
       }
     },
     "node_modules/parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.0.1.tgz",
+      "integrity": "sha1-B0lfaw5Ui+xipkQtRL9JStKshK8=",
       "dependencies": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-path-regex": "^1.0.0",
+        "is-glob": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -15512,22 +15479,10 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "^2.0.0"
-      }
+    "glob-path-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-path-regex/-/glob-path-regex-1.0.0.tgz",
+      "integrity": "sha1-E4OpjJ7fDv84Dth3qIcqrl6UB50="
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -15870,16 +15825,6 @@
         "has": "^1.0.3"
       }
     },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -15887,12 +15832,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "^1.0.0"
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
+      "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU="
     },
     "is-module": {
       "version": "1.0.0",
@@ -19518,14 +19460,12 @@
       }
     },
     "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-2.0.1.tgz",
+      "integrity": "sha1-B0lfaw5Ui+xipkQtRL9JStKshK8=",
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-path-regex": "^1.0.0",
+        "is-glob": "^1.1.0"
       }
     },
     "parse-json": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "commander": "5.1.0",
     "glob": "^7.2.0",
     "node-fetch": "^2.6.2",
-    "parse-glob": "3.0.4",
+    "parse-glob": "^2.0.1",
     "strip-json-comments": "3.1.0",
     "xml": "1.0.1"
   },


### PR DESCRIPTION
***Short description of what this resolves:***
Downgrade to version recommended by npm audit.
This is just a workaround, but a longer term fix would be to replace the package with something else

***Proposed changes:***

