### PR TITLE
refactor(htmlparser): remove unused variable for @typescript-eslint/no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,6 @@ module.exports = {
         '@typescript-eslint/no-unsafe-assignment': 'off',
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/restrict-template-expressions': 'off',
       },

--- a/src/core/htmlparser.ts
+++ b/src/core/htmlparser.ts
@@ -110,8 +110,7 @@ export default class HTMLParser {
       arrBlocks.push(data)
       this.fire(type, data)
 
-      let lineMatch: RegExpExecArray | null
-      while ((lineMatch = regLine.exec(raw))) {
+      while (regLine.exec(raw)) {
         line++
         lastLineIndex = pos + regLine.lastIndex
       }


### PR DESCRIPTION
***Short description of what this resolves:***
Looking at the compiled code, this doesn't change the output, since it trimmed it off anyway during compile

***Proposed changes:***

