### PR TITLE
refactor(formatter): update order for @typescript-eslint/adjacent-overload-signatures

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
         'template-tag-spacing': 'error',
         quotes: ['error', 'single', { avoidEscape: true }],
 
-        '@typescript-eslint/adjacent-overload-signatures': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/no-unsafe-argument': 'off',
         '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -67,15 +67,13 @@ export interface Formatter extends EventEmitter {
   setFormat(format: string): void
 
   emit(event: 'start'): boolean
-  on(event: 'start', listener: () => void): this
-
   emit(event: 'file', arg: FormatterFileEvent): boolean
-  on(event: 'file', listener: (event: FormatterFileEvent) => void): this
-
   emit(event: 'config', arg: FormatterConfigEvent): boolean
-  on(event: 'config', listener: (event: FormatterConfigEvent) => void): this
-
   emit(event: 'end', arg: FormatterEndEvent): boolean
+
+  on(event: 'start', listener: () => void): this
+  on(event: 'file', listener: (event: FormatterFileEvent) => void): this
+  on(event: 'config', listener: (event: FormatterConfigEvent) => void): this
   on(event: 'end', listener: (event: FormatterEndEvent) => void): this
 }
 


### PR DESCRIPTION
***Short description of what this resolves:***
No funtional change to compiled code, except for sourceMap line

***Proposed changes:***

