### PR TITLE
ci: ensure files are built

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -71,6 +71,9 @@ jobs:
         env:
           CI: true
 
+      - name: Ensure no git changes
+        run: git diff --exit-code
+
       - name: Run coverage
         run: npm run test:coverage
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -70,6 +70,9 @@ jobs:
         env:
           CI: true
 
+      - name: Ensure no git changes
+        run: git diff --exit-code
+
       - name: Run coverage
         run: npm run test:coverage
 


### PR DESCRIPTION
***Short description of what this resolves:***
I expect this to fail currently, but the idea is to ensure the built files are included by PRs to show any changes to the output.
Maybe this isn't desired as the churn it might cause on those files

***Proposed changes:***

