### PR TITLE
ci: sync semantic-release plugin versions

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -95,6 +95,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v2
         with:
+          node-version: 14
           cache: npm
 
       - name: 📥 Download deps
@@ -110,8 +111,8 @@ jobs:
         with:
           semantic_version: 17
           extra_plugins: |
-            @semantic-release/changelog@3.0.0
-            @semantic-release/git@9.0.0
+            @semantic-release/changelog@6
+            @semantic-release/git@10
           branches: |
             [
               'master',

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -23,6 +23,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v2
         with:
+          node-version: 14
           cache: npm
 
       - name: 📥 Download deps
@@ -39,8 +40,8 @@ jobs:
           dry_run: true
           semantic_version: 17
           extra_plugins: |
-            @semantic-release/changelog@3.0.0
-            @semantic-release/git@9.0.0
+            @semantic-release/changelog@6
+            @semantic-release/git@10
           branches: |
             [
               'master',


### PR DESCRIPTION
***Short description of what this resolves:***
Pulling this from the other PR as it's unrelated. This started to have an issue as described over https://github.com/cycjimmy/semantic-release-action/issues/79#issuecomment-924607478

***Proposed changes:***

