### PR TITLE
ci: don't trigger for website content

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,7 +10,10 @@ on:
       - beta
       - next
       - next-major
-    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'website/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
 jobs:
   lint:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,6 +10,10 @@ on:
       - next
       - next-major
       - '!all-contributors/**'
+    paths-ignore:
+      - 'website/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
 jobs:
   lint:

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -10,7 +10,10 @@ on:
       - beta
       - next
       - next-major
-    types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'website/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
 jobs:
   test-release:


### PR DESCRIPTION
***Short description of what this resolves:***
Noticed that the Dependabot PRs were triggering the main CI flow for website updates. There are some random failutes for that right now, but this will skip running on those content changes and just run the `website.yml` flow only

***Proposed changes:***

