### PR TITLE
ci: retry coverage builds for flakey macOS runs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,13 +3,8 @@ name: Development workflow
 on:
   pull_request:
     branches:
-      - '+([0-9])?(.{+([0-9]),x}).x'
-      - main
       - master
-      - alpha
-      - beta
-      - next
-      - next-major
+      - main
     paths-ignore:
       - 'website/**'
       - '**/*.md'
@@ -34,8 +29,6 @@ jobs:
         run: npm run lint
 
   build:
-    # ignore all-contributors PRs
-    if: ${{ !contains(github.head_ref, 'all-contributors') }}
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
@@ -73,7 +66,11 @@ jobs:
         run: git diff --exit-code
 
       - name: Run coverage
-        run: npm run test:coverage
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: npm run test:coverage
 
       - name: ⬆️ Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
       - master
-      - alpha
-      - beta
-      - next
-      - next-major
-      - '!all-contributors/**'
     paths-ignore:
       - 'website/**'
       - '**/*.md'
@@ -34,8 +29,6 @@ jobs:
         run: npm run lint
 
   build:
-    # ignore all-contributors PRs
-    if: ${{ !contains(github.head_ref, 'all-contributors') }}
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
@@ -73,7 +66,11 @@ jobs:
         run: git diff --exit-code
 
       - name: Run coverage
-        run: npm run test:coverage
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: npm run test:coverage
 
       - name: ⬆️ Upload coverage to Codecov
         uses: codecov/codecov-action@v2


### PR DESCRIPTION
***Short description of what this resolves:***

Since the CLI tests on macOS seem to randomly fail waiting for the rest of stdin, retry 3 times instead of manually restarting the job

***Proposed changes:***

