### PR TITLE
fix: update Editor Extensions page on site

### DIFF
--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -3,8 +3,8 @@ id: editor
 title: Editor integrations
 ---
 
-Editor integrations built and maintained by the HTMLHint organization and some by the community.
+Editor integrations built and maintained by the HTMLHint organization.
 
 - [atom-htmlhint](https://github.com/htmlhint/atom-htmlhint) - Atom plugin for HTMLHint.
 - [SublimeLinter-contrib-htmlhint](https://github.com/htmlhint/SublimeLinter-contrib-htmlhint) - Sublime Text plugin for HTMLHint.
-- [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=mkaufman.HTMLHint) - VS Code extension for HTMLHint.
+- [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhintt) - VS Code extension for HTMLHint.


### PR DESCRIPTION
Add link to the new VS Code extension:
https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint