### PR TITLE
fix: update Node version for deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.14]
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This sets the min Node version so that website build doesn't fail.

This should fix this error:
![5DMsOVhg](https://user-images.githubusercontent.com/1212885/193721037-18f490bc-e7d1-4873-b207-124b09e3d005.jpg)

Thanks for pointing this out @thedaviddias !

