### PR TITLE
fix: typo on VS Code extension name

### DIFF
--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -7,4 +7,4 @@ Editor integrations built and maintained by the HTMLHint organization.
 
 - [atom-htmlhint](https://github.com/htmlhint/atom-htmlhint) - Atom plugin for HTMLHint.
 - [SublimeLinter-contrib-htmlhint](https://github.com/htmlhint/SublimeLinter-contrib-htmlhint) - Sublime Text plugin for HTMLHint.
-- [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhintt) - VS Code extension for HTMLHint.
+- [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint) - VS Code extension for HTMLHint.


### PR DESCRIPTION
typo on VS Code extension name.

https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhintt
should be:
https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint

