### PR TITLE
Docs: Remove Atom extension

### DIFF
--- a/docs/user-guide/integrations/editor.md
+++ b/docs/user-guide/integrations/editor.md
@@ -5,6 +5,5 @@ title: Editor integrations
 
 Editor integrations built and maintained by the HTMLHint organization.
 
-- [atom-htmlhint](https://github.com/htmlhint/atom-htmlhint) - Atom plugin for HTMLHint.
 - [SublimeLinter-contrib-htmlhint](https://github.com/htmlhint/SublimeLinter-contrib-htmlhint) - Sublime Text plugin for HTMLHint.
 - [vscode-htmlhint](https://marketplace.visualstudio.com/items?itemName=HTMLHint.vscode-htmlhint) - VS Code extension for HTMLHint.


### PR DESCRIPTION
The Atom HTMLHint plugin is archived, and the Atom editor is end-of-life and will be archived in December 2022 so may as well remove the link.
