### PR TITLE
docs(attr-whitespace): remove example space

### DIFF
--- a/docs/user-guide/rules/attr-whitespace.md
+++ b/docs/user-guide/rules/attr-whitespace.md
@@ -25,5 +25,5 @@ The following pattern is considered violation:
 ```html
 <div title=" a"></div>
 <div title="a "></div>
-<div title =" a "></div>
+<div title=" a "></div>
 ```


### PR DESCRIPTION
The rule is for whitespace inside an attribute, but the sample makes it look like it's also for surrounding whitespace
