### PR TITLE
chore: change dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,17 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 99
+      interval: monthly
   - package-ecosystem: npm
     directory: '/website'
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 99
+      interval: monthly
   - package-ecosystem: npm
     directory: '/website/plugins/docusaurus-plugin-hotjar'
     schedule:
-      interval: weekly
+      interval: monthly
     versioning-strategy: increase
-    open-pull-requests-limit: 99
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: weekly
-    open-pull-requests-limit: 99


### PR DESCRIPTION
Let's set it to run monthly or npm package checks instead of weekly to reduce the noise. We can remove the limit and default to default of 5... once a PR is merged it should auto-check again and open any new ones needed.
