### PR TITLE
Update Node versions used on GitHub Actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -37,7 +37,7 @@ jobs:
         node:
           - 14
           - 16
-          - 17
+          - 18
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,7 +37,7 @@ jobs:
         node:
           - 14
           - 16
-          - 17
+          - 18
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -109,7 +109,7 @@ jobs:
         run: npm run build
 
       - name: 🚢 Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           extra_plugins: |
             @semantic-release/changelog

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run build
 
       - name: 🚢 Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           dry_run: true
           extra_plugins: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
         "rollup": "^2.60.1",
         "rollup-plugin-terser": "^7.0.2",
         "typescript": "^4.5.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "git+https://github.com/htmlhint/HTMLHint.git"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "license": "MIT",
   "main": "dist/htmlhint.js",
   "module": "dist/core/core.js",


### PR DESCRIPTION
Use v14, v16 and v18.
REF: https://github.com/nodejs/release#release-schedule
