### PR TITLE
fix(spec-char-escape): remove normal ampersand from spec-char-escape …

### DIFF
--- a/docs/user-guide/rules/spec-char-escape.md
+++ b/docs/user-guide/rules/spec-char-escape.md
@@ -12,11 +12,13 @@ Level: `error`
 1. true: enable rule
 2. false: disable rule
 
-The following pattern are **not** considered violations:
+The following patterns are **not** considered violations:
 
 <!-- prettier-ignore -->
 ```html
 <span>aaa&gt;bbb&lt;ccc</span>
+<span>Steinway &amp; Sons, Q&amp;A</span>
+<span>Steinway & Sons, Q&A</span>
 ```
 
 The following pattern is considered violation:

--- a/src/core/rules/spec-char-escape.ts
+++ b/src/core/rules/spec-char-escape.ts
@@ -6,7 +6,6 @@ export default {
   init(parser, reporter) {
     parser.addListener('text', (event) => {
       const raw = event.raw
-      // TODO: improve use-cases for &
       const reSpecChar = /([<>])/g
       let match
 

--- a/src/core/rules/spec-char-escape.ts
+++ b/src/core/rules/spec-char-escape.ts
@@ -7,7 +7,7 @@ export default {
     parser.addListener('text', (event) => {
       const raw = event.raw
       // TODO: improve use-cases for &
-      const reSpecChar = /([<>])|( \& )/g
+      const reSpecChar = /([<>])/g
       let match
 
       while ((match = reSpecChar.exec(raw))) {

--- a/test/rules/spec-char-escape.spec.js
+++ b/test/rules/spec-char-escape.spec.js
@@ -21,13 +21,10 @@ describe(`Rules: ${ruleId}`, () => {
     expect(messages[2].col).toBe(4)
   })
 
-  it('Special characters: & should result in an error', () => {
-    const code = '<p>Steinway & Sons</p>'
+  it('Special characters: normal & should not result in an error', () => {
+    const code = '<p>Steinway & Sons Q&A</p>'
     const messages = HTMLHint.verify(code, ruleOptions)
-    expect(messages.length).toBe(1)
-    expect(messages[0].rule.id).toBe(ruleId)
-    expect(messages[0].line).toBe(1)
-    expect(messages[0].col).toBe(12)
+    expect(messages.length).toBe(0)
   })
 
   it('Normal text should not result in an error', () => {


### PR DESCRIPTION
Remove normal ampersand from spec-char-escape rule, update test and docs.

fix #1382

***Short description of what this resolves:***

Ampersand is acceptable in HTML text. W3C Markup Validation Service no longer finds any issues with the uncoded &.

***Proposed changes:***

