### PR TITLE
fix(tag-pair) point tag-pair to correct line and column number

### DIFF
--- a/src/core/rules/tag-pair.ts
+++ b/src/core/rules/tag-pair.ts
@@ -16,6 +16,7 @@ export default {
         stack.push({
           tagName: tagName,
           line: event.line,
+          col: event.col,
           raw: event.raw,
         })
       }
@@ -46,8 +47,8 @@ export default {
             )} ], start tag match failed [ ${lastEvent.raw} ] on line ${
               lastEvent.line
             }.`,
-            event.line,
-            event.col,
+            lastEvent.line || event.line,
+            lastEvent.col || event.col,
             this,
             event.raw
           )

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -29,10 +29,10 @@ describe(`Rules: ${ruleId}`, () => {
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).toBe(1)
     expect(messages[0].rule.id).toBe(ruleId)
-    expect(messages[0].line).toBe(2)
     expect(messages[0].line).not.toBe(4)
-    expect(messages[0].col).toBe(3)
     expect(messages[0].col).not.toBe(1)
+    expect(messages[0].line).toBe(2)
+    expect(messages[0].col).toBe(3)
   })
 
   it('No start tag should result in an error', () => {

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -12,7 +12,7 @@ describe(`Rules: ${ruleId}`, () => {
     expect(messages.length).toBe(2)
     expect(messages[0].rule.id).toBe(ruleId)
     expect(messages[0].line).toBe(1)
-    expect(messages[0].col).toBe(9)
+    expect(messages[0].col).toBe(5)
     expect(messages[1].rule.id).toBe(ruleId)
     expect(messages[1].line).toBe(1)
     expect(messages[1].col).toBe(20)

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -24,7 +24,7 @@ describe(`Rules: ${ruleId}`, () => {
     expect(messages[0].col).toBe(9)
   })
 
-  it('No end tag should result in an error with correct line number and column of the start tag.', () => {
+  it('No end tag should result in an error with correct line number and column of the start tag', () => {
     const code = '<div>\r\n  <h1>\r\n    <p>aaa</p>\r\n</div>'
     const messages = HTMLHint.verify(code, ruleOptions)
     expect(messages.length).toBe(1)

--- a/test/rules/tag-pair.spec.js
+++ b/test/rules/tag-pair.spec.js
@@ -24,6 +24,17 @@ describe(`Rules: ${ruleId}`, () => {
     expect(messages[0].col).toBe(9)
   })
 
+  it('No end tag should result in an error with correct line number and column of the start tag.', () => {
+    const code = '<div>\r\n  <h1>\r\n    <p>aaa</p>\r\n</div>'
+    const messages = HTMLHint.verify(code, ruleOptions)
+    expect(messages.length).toBe(1)
+    expect(messages[0].rule.id).toBe(ruleId)
+    expect(messages[0].line).toBe(2)
+    expect(messages[0].line).not.toBe(4)
+    expect(messages[0].col).toBe(3)
+    expect(messages[0].col).not.toBe(1)
+  })
+
   it('No start tag should result in an error', () => {
     const code = '</div>'
     const messages = HTMLHint.verify(code, ruleOptions)


### PR DESCRIPTION
***Short description of what this resolves:***

Point tag-pair to correct line and column number of the start tag, if no end tag
fix #1284 


