### PR TITLE
fix(id-class-value): fix ineficient regex

### DIFF
--- a/src/core/rules/id-class-value.ts
+++ b/src/core/rules/id-class-value.ts
@@ -17,7 +17,7 @@ export default {
           'The id and class attribute values must be in lowercase and split by a dash.',
       },
       hump: {
-        regId: /^[a-z][a-zA-Z\d]*(?:[A-Z][a-zA-Z\d]*)*$/,
+        regId: /^[a-z](?=[a-zA-Z\d]*$)(?:[a-zA-Z\d]*(?:[A-Z][a-zA-Z\d]*)*)?$/,
         message:
           'The id and class attribute values must meet the camelCase style.',
       },

--- a/src/core/rules/id-class-value.ts
+++ b/src/core/rules/id-class-value.ts
@@ -17,7 +17,7 @@ export default {
           'The id and class attribute values must be in lowercase and split by a dash.',
       },
       hump: {
-        regId: /^[a-z][a-zA-Z\d]*([A-Z][a-zA-Z\d]*)*$/,
+        regId: /^[a-z][a-zA-Z\d]*(?:[A-Z][a-zA-Z\d]*)*$/,
         message:
           'The id and class attribute values must meet the camelCase style.',
       },


### PR DESCRIPTION
Replacing the capturing group quantifier ( ... )* with a non-capturing group quantifier (?: ... )* to reduce the risk of exponential backtracking.

#1147

***Short description of what this resolves:***

Reduce risk of exponential backtracking in rule id-class-value

***Proposed changes:***

