### PR TITLE
chore: group Dependabot minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,29 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: increase
+    open-pull-requests-limit: 99
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: npm
     directory: '/website'
     schedule:
       interval: monthly
     versioning-strategy: increase
+    open-pull-requests-limit: 99
+    groups:
+      dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
   - package-ecosystem: npm
     directory: '/website/plugins/docusaurus-plugin-hotjar'
     schedule:


### PR DESCRIPTION
To reduce some of the Dependabot PRs, this will pull all minor/patch updates to single PRs, but leave majors on their own