### PR TITLE
feat: tsconfig - forceConsistentCasingInFileNames

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
     "removeComments": true
   },
   "include": ["src"],


### PR DESCRIPTION
***Short description of what this resolves:***

If you are working on a project where developers use different OSes (e.g.: Windows and Linux), enabling this property will prevent issues related to the file casing and how the files are referenced in the code.

REF: https://webhint.io/docs/user-guide/hints/hint-typescript-config/consistent-casing/