### PR TITLE
docs: remove browserconfig.xml

### DIFF
--- a/website/static/img/browserconfig.xml
+++ b/website/static/img/browserconfig.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<browserconfig>
-    <msapplication>
-        <tile>
-            <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#2b5797</TileColor>
-        </tile>
-    </msapplication>
-</browserconfig>


### PR DESCRIPTION
I think this was only needed for Legacy Edge and Internet Explorer. REF: https://danaleegibson.com/what-is-the-browserconfig-dot-xml/

***Short description of what this resolves:***


***Proposed changes:***

