### PR TITLE
docs: badge update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 <h4 align="center">The static code analysis tool you need for your HTML.</h4>
 
 <p align="center">
-  <a href="https://travis-ci.org/htmlhint/HTMLHint">
-    <img src="https://img.shields.io/travis/htmlhint/HTMLHint.svg" alt="Travis Build Status">
+  <a href="https://www.npmjs.com/package/htmlhint">
+    <img src="https://img.shields.io/npm/v/htmlhint" alt="npm Version">
   </a>
   <a href="https://codecov.io/gh/htmlhint/HTMLHint">
     <img src="https://codecov.io/gh/htmlhint/HTMLHint/branch/master/graph/badge.svg" alt="Codecov">
@@ -18,7 +18,9 @@
   <a href="https://www.npmjs.com/package/htmlhint">
     <img src="https://img.shields.io/npm/dm/htmlhint.svg" alt="npm count">
   </a>
-  <img src="https://badgen.net/badge/license/MIT/green" alt="MIT License" />
+  <a href="https://github.com/htmlhint/HTMLHint/blob/master/LICENSE.md">
+    <img src="https://badgen.net/badge/license/MIT/green" alt="MIT License" />
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Fixes: #1540

- Removes broken Travis badge
- Adds link to the LICENSE file on GitHub from LICENSE badge
- Add npm version badge