### PR TITLE
fix: documentation test

### DIFF
--- a/test/rules/documentation.spec.js
+++ b/test/rules/documentation.spec.js
@@ -12,12 +12,20 @@ describe('Rules documentation', () => {
 
   let docs = fs
     .readdirSync(
-      path.join(__dirname, '..', '..', 'docs', 'user-guide', 'rules')
+      path.join(__dirname, '..', '..', 'website', 'docs', 'user-guide', 'rules')
     )
     .map((doc) => doc.replace('.md', ''))
 
   const rulesListPage = fs.readFileSync(
-    path.join(__dirname, '..', '..', 'docs', 'user-guide', 'list-rules.md'),
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      'website',
+      'docs',
+      'user-guide',
+      'list-rules.md'
+    ),
     'utf-8'
   )
 


### PR DESCRIPTION
Add `website` to the path to fix the file not found error.
