### PR TITLE
Change default branch from master to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,11 +3,11 @@ name: 'CodeQL'
 on:
   push:
     branches:
-      - master
+      - main
       - '!dependabot/**'
   pull_request:
     branches:
-      - master
+      - main
       - '!dependabot/**'
 
 jobs:

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -3,7 +3,6 @@ name: Development workflow
 on:
   pull_request:
     branches:
-      - master
       - main
     paths-ignore:
       - 'website/**'

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
     paths-ignore:
       - 'website/**'
       - '**/*.md'
@@ -90,7 +89,7 @@ jobs:
 
   release:
     if: ${{ github.repository == 'htmlhint/HTMLHint' &&
-      contains('refs/heads/master,refs/heads/beta,refs/heads/next,refs/heads/alpha',
+      contains('refs/heads/main,refs/heads/beta,refs/heads/next,refs/heads/alpha',
       github.ref) && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: build
@@ -117,7 +116,7 @@ jobs:
             @semantic-release/git
           branches: |
             [
-              'master',
+              'main',
               'next',
               'next-major',
               {name: 'beta', prerelease: true},

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,9 +1,9 @@
 name: 'Check spelling'
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Super-linter
         uses: super-linter/super-linter/slim@v7
         env:
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IGNORE_GITIGNORED_FILES: true
           LINTER_RULES_PATH: /

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,7 +4,7 @@ name: Sync labels
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/labels.yml
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - '+([0-9])?(.{+([0-9]),x}).x'
       - main
-      - master
       - alpha
       - beta
       - next
@@ -43,7 +42,7 @@ jobs:
             @semantic-release/git
           branches: |
             [
-              'master',
+              'main',
               'next',
               'next-major',
               {name: 'beta', prerelease: true},

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,6 @@
 {
   "branches": [
-    "master",
+    "main",
     { "name": "alpha", "prerelease": true },
     { "name": "beta", "prerelease": true }
   ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <a href="https://htmlhint.com"><img src="https://raw.githubusercontent.com/htmlhint/HTMLHint/master/website/static/img/htmlhint.png" alt="Logo HTMLHint" width="170"></a>
+  <a href="https://htmlhint.com"><img src="https://raw.githubusercontent.com/htmlhint/HTMLHint/main/website/static/img/htmlhint.png" alt="Logo HTMLHint" width="170"></a>
   <br>
   HTMLHint
   <br>
@@ -13,12 +13,12 @@
     <img src="https://img.shields.io/npm/v/htmlhint" alt="npm Version">
   </a>
   <a href="https://codecov.io/gh/htmlhint/HTMLHint">
-    <img src="https://codecov.io/gh/htmlhint/HTMLHint/branch/master/graph/badge.svg" alt="Codecov">
+    <img src="https://codecov.io/gh/htmlhint/HTMLHint/branch/main/graph/badge.svg" alt="Codecov">
   </a>
   <a href="https://www.npmjs.com/package/htmlhint">
     <img src="https://img.shields.io/npm/dm/htmlhint.svg" alt="npm count">
   </a>
-  <a href="https://github.com/htmlhint/HTMLHint/blob/master/LICENSE.md">
+  <a href="https://github.com/htmlhint/HTMLHint/blob/main/LICENSE.md">
     <img src="https://badgen.net/badge/license/MIT/green" alt="MIT License" />
   </a>
 </p>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
         docs: {
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: `${GITHUB_URL}/edit/master/website/`,
+          editUrl: `${GITHUB_URL}/edit/main/website/`,
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
         },


### PR DESCRIPTION
`main` is the default branch name for GitHub and makes sense to use this.

Note: ignore failing test/linting because it's checking main but we haven't updated default branch in settings yet!