### PR TITLE
Docs: Add missing usage section from sidebar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -118,6 +118,11 @@ export default defineConfig({
           autogenerate: { directory: 'rules' },
         },
         {
+          label: 'Usage',
+          collapsed: true,
+          autogenerate: { directory: 'usage' },
+        },
+        {
           label: 'VS Code Extension',
           link: '/vs-code-extension/',
         },

--- a/website/src/content/docs/usage/cli.md
+++ b/website/src/content/docs/usage/cli.md
@@ -13,7 +13,7 @@ Use `npx htmlhint --help` to print the CLI documentation.
 
 ## Options
 
-In addition to the [standard options](options), the CLI accepts:
+In addition to the [standard options](/usage/options), the CLI accepts:
 
 ### `--color, --no-color`
 

--- a/website/src/content/docs/usage/options.md
+++ b/website/src/content/docs/usage/options.md
@@ -7,7 +7,7 @@ title: Options
 
 CLI flag: `--config`
 
-Path to a JSON file that contains your [configuration object](../configuration.md).
+Path to a JSON file that contains your [configuration object](/configuration/).
 
 Use this option if you don't want HTMLHint to search for a configuration file.
 


### PR DESCRIPTION
There was previously a Usage section on sidebar which somehow got missed when we migrated the site to Astro Starlight.

REF: https://web.archive.org/web/20250316190716/https://htmlhint.com/docs/user-guide/usage/cli