### PR TITLE
Tests: Remove console logs from tests

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,9 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true

--- a/test/cli/formatters/compact.spec.js
+++ b/test/cli/formatters/compact.spec.js
@@ -2,15 +2,7 @@ const ChildProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
-jest.setTimeout(60000) // Set timeout to 60 seconds
-
-// Add timing logs to debug execution time
 describe('CLI', () => {
-  console.time('Test Execution Time')
-  afterAll(() => {
-    console.timeEnd('Test Execution Time')
-  })
-
   describe('Formatter: compact', () => {
     it('should have stdout output with formatter compact', (done) => {
       const expected = fs

--- a/test/cli/formatters/default.spec.js
+++ b/test/cli/formatters/default.spec.js
@@ -12,7 +12,6 @@ describe('CLI', () => {
           path.resolve(__dirname, '../../html/executable.html'),
         ].join(' '),
         (error, stdout, stderr) => {
-          console.log('Actual stdout:', stdout) // Debugging line
           expect(typeof error).toBe('object')
           expect(error.code).toBe(1)
 

--- a/test/cli/formatters/unix.spec.js
+++ b/test/cli/formatters/unix.spec.js
@@ -25,7 +25,6 @@ describe('CLI', () => {
           'unix',
         ].join(' '),
         (error, stdout, stderr) => {
-          console.log('Actual stdout:', stdout) // Debugging line
           expect(typeof error).toBe('object')
           expect(error.code).toBe(1)
 


### PR DESCRIPTION
We added these console logs a few weeks ago to help debug when we had issues with tests completing, but all issues are resolved now so we can remove this to keep the CLI cleaner/faster.

Also added Gemini config to optimize the GitHub code reviews.
