### PR TITLE
Docs: Hide h1 require rule

### DIFF
--- a/website/src/content/docs/rules/h1-require.mdx
+++ b/website/src/content/docs/rules/h1-require.mdx
@@ -2,6 +2,9 @@
 id: h1-require
 title: h1-require
 description: Ensures that an HTML document contains at least one `<h1>` element for proper document structure and accessibility.
+sidebar:
+  hidden: true
+  badge: New
 ---
 import { Badge } from '@astrojs/starlight/components';
 

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -97,3 +97,7 @@ h3[id^='the-following-patterns-are-not']::before {
   background-image: url('/img/yes.svg');
   background-size: 140%;
 }
+
+.top-level li a span.sl-badge {
+  opacity: 0.5;
+}


### PR DESCRIPTION
This rule hasn't been published to npmjs yet so let's hide it from sidebar. I added the New badge so when it is ready it'll show that badge. :-) 