### PR TITLE
docs: swap X to Mastodon

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,9 +28,9 @@ export default defineConfig({
           href: 'https://github.com/htmlhint/htmlhint',
         },
         {
-          icon: 'x.com',
-          label: 'x',
-          href: 'https://x.com/htmlhint',
+          icon: 'mastodon',
+          label: 'Mastodon',
+          href: 'https://mastodon.social/@htmlhint',
         },
         {
           icon: 'openCollective',
@@ -100,6 +100,13 @@ export default defineConfig({
           attrs: {
             name: 'color-scheme',
             content: 'light dark',
+          },
+        },
+        {
+          tag: 'meta',
+          attrs: {
+            name: 'fediverse:creator',
+            content: '@htmlhint@mastodon.social',
           },
         },
       ],

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Welcome to HTMLHint
-description: The web's most popular Static code analysis tool you need for your HTML. Available as a CLI tool, VS Code extension, and more.
+description: The web's most popular static code analysis tool you need for your HTML. Available as a CLI tool, VS Code extension, and more.
 hero:
-  tagline: The web's most popular Static code analysis tool you need for your HTML
+  tagline: The web's most popular static code analysis tool you need for your HTML
   image:
     file: ../../assets/img/htmlhint.webp
   actions:


### PR DESCRIPTION
This pull request updates the website configuration and content to improve social media integration and fix a minor text inconsistency. The most important changes include replacing the link to X with a Mastodon link, adding a meta tag for Fediverse creator information, and correcting capitalization in the tagline and description.

### Social Media Integration:
* Updated the social media link in `website/astro.config.mjs` to replace the X link with a Mastodon link, including changes to the `icon`, `label`, and `href` properties.
* Added a meta tag in `website/astro.config.mjs` for the Fediverse creator information, specifying the Mastodon handle `@htmlhint@mastodon.social`.

### Content Fixes:
* Corrected capitalization in the tagline and description in `website/src/content/docs/index.mdx` by changing "Static" to "static" for consistency.