### PR TITLE
chore: Update Prettier to v3.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: monthly
+      interval: weekly
     versioning-strategy: increase
     groups:
       dependencies:
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: npm
     directory: '/website'
     schedule:
-      interval: monthly
+      interval: weekly
     versioning-strategy: increase
     groups:
       dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint-plugin-prettier": "^5.5.0",
         "jest": "^30.0.2",
         "parse-glob": "3.0.4",
-        "prettier": "3.5.3",
+        "prettier": "3.6.0",
         "rimraf": "6.0.1",
         "rollup": "4.44.0",
         "typescript": "5.4.5"
@@ -5748,9 +5748,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-prettier": "^5.5.0",
     "jest": "^30.0.2",
     "parse-glob": "3.0.4",
-    "prettier": "3.5.3",
+    "prettier": "3.6.0",
     "rimraf": "6.0.1",
     "rollup": "4.44.0",
     "typescript": "5.4.5"

--- a/website/src/content/docs/usage/custom-rules.mdx
+++ b/website/src/content/docs/usage/custom-rules.mdx
@@ -6,8 +6,6 @@ sidebar:
   order: 4
 ---
 
-# Custom Rules
-
 HTMLHint allows you to create custom rules to extend its functionality for your specific needs. Custom rules can be loaded using the `--rulesdir` option and follow the same pattern as built-in rules.
 
 ## Creating Custom Rules


### PR DESCRIPTION
This pull request includes updates to dependency management and minor content adjustments. The most important changes involve modifying the Dependabot update schedule, upgrading the `prettier` dependency, and refining the documentation structure.

### Dependency Management Updates:
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6): Changed the update schedule for npm dependencies in both the root directory and the `/website` directory from monthly to weekly to ensure more frequent updates. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R6) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L19-R19)

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L75-R75): Upgraded the `prettier` dependency from version `3.5.3` to `3.6.0` for improved formatting capabilities and bug fixes.

### Documentation Adjustments:
* [`website/src/content/docs/usage/custom-rules.mdx`](diffhunk://#diff-7acae4b22fe557701b94fa1f7047660ba2089505933030d4a17ccbf12052c26dL9-L10): Removed the redundant "Custom Rules" heading to streamline the structure and improve readability.