### PR TITLE
Update Node.js engine, workflows, and test coverage

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -3,6 +3,16 @@ description: General rules for the project
 globs:
 alwaysApply: true
 ---
-- When adding a new rule to website ensure that it has the frontmatter: `pagefind: false   sidebar:   badge: New  hidden: true`
-- Always run `npm run lint` before declaring that a task is complete (if you've changed any files)
 
+- When adding a new rule to website ensure that it has the frontmatter: `pagefind: false   sidebar:   badge: New  hidden: true`.
+- Always run `npm run lint` before declaring that a task is complete (if you've changed any files).
+- Always use lf for line endings.
+- Code is formatted with prettier.
+- As a general rule, rules should be listed alphabetically.
+
+## GitHub Actions
+
+- The GitHub Actions workflows should be placed in the .github/workflows directory.
+- The workflows should be named `<workflow-name>.yml`.
+- All GitHub Actions should be pinned versions to avoid breaking changes (SHA-1).
+- If using actions/checkout, it should have `persist-credentials: false` set.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 - Node v20 is used for development.
 - Core code is in TypeScript v5.4.5.
 - All new rules for HTMLHint should be placed in the rules directory.
-- Tests for new rules should be added in rules and follow the naming pattern <rule-name>.spec.js.
+- Tests for new rules should be added in rules and follow the naming pattern `<rule-name>.spec.js`.
 - Do not use deprecated Node.js or TypeScript features.
 - All user-facing messages and documentation should use clear, concise US English.
 - Keep dependencies up to date and avoid unnecessary packages.
@@ -19,3 +19,10 @@
 - Use the provided code snippets as examples for rule documentation.
 - Newly added rules pages for the website should have the frontmatter: sidebar: hidden: true badge: New
 - Always run `npm run build` before running tests or committing changes.
+
+## GitHub Actions
+
+- The GitHub Actions workflows should be placed in the .github/workflows directory.
+- The workflows should be named `<workflow-name>.yml`.
+- All GitHub Actions should be pinned versions to avoid breaking changes (SHA-1).
+- If using actions/checkout, it should have `persist-credentials: false` set.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,11 +30,11 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
+        uses: github/codeql-action/init@d3678e237b9c32a6c9bffb3315c335f976f3549f # v3.30.2
         with:
           config-file: ./.github/codeql/codeql-config.yml
           languages: 'javascript'
           queries: +security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f1f6e5f6af878fb37288ce1c627459e94dbf7d01 # v3.30.1
+        uses: github/codeql-action/analyze@d3678e237b9c32a6c9bffb3315c335f976f3549f # v3.30.2

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Pull Request Labeler
 
 on:
-  - pull_request_target
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -9,8 +9,8 @@ permissions:
 jobs:
   triage:
     permissions:
-      contents: read  # for actions/labeler to determine modified files
-      pull-requests: write  # for actions/labeler to add labels to PRs
+      contents: read # for actions/labeler to determine modified files
+      pull-requests: write # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,15 @@ jobs:
 
   build:
     permissions:
-      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
-      contents: read  # for actions/checkout to fetch code
+      actions: write # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read # for actions/checkout to fetch code
     runs-on: ${{ matrix.os }}
     needs: lint
     strategy:
       fail-fast: false
       matrix:
         node:
+          - 18
           - 20
           - 22
           - 24

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,8 +19,8 @@ permissions:
 jobs:
   build:
     permissions:
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "5.4.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "funding": {
         "type": "Open Collective",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "typescript": "5.4.5"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "volta": {
     "node": "20.19.4"

--- a/test/rules/documentation.spec.js
+++ b/test/rules/documentation.spec.js
@@ -25,27 +25,9 @@ describe('Rules documentation', () => {
     )
     .map((doc) => doc.replace('.mdx', ''))
 
-  const rulesListPage = fs.readFileSync(
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      'website',
-      'src',
-      'content',
-      'docs',
-      'rules',
-      'index.mdx'
-    ),
-    'utf-8'
-  )
-
   rules.forEach((rule) => {
     it(`${rule} should have a documentation page`, () => {
       expect(docs).toContain(rule)
-    })
-    it(`${rule} should be on the rules/index.mdx`, () => {
-      expect(rulesListPage).toContain(rule)
     })
   })
 })


### PR DESCRIPTION
- Lowered the minimum Node.js engine requirement to 18 in package.json and added Node.js 18 to the test matrix.
- Updated CodeQL GitHub Actions to v3.30.2 and improved documentation for GitHub Actions usage.
- Removed a test that checked for rule presence in rules/index.mdx. (because we don't put rules live on the website until new version is published).
