### PR TITLE
docs: Update rules and GitHub Actions

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
 open_collective: htmlhint
+ko_fi: coliff
+github: coliff

--- a/website/src/content/docs/rules/h1-require.mdx
+++ b/website/src/content/docs/rules/h1-require.mdx
@@ -2,8 +2,6 @@
 id: h1-require
 title: h1-require
 description: Ensures that an HTML document contains at least one `<h1>` element for proper document structure and accessibility.
-sidebar:
-  badge: New
 ---
 
 import { Badge } from '@astrojs/starlight/components';

--- a/website/src/content/docs/rules/main-require.mdx
+++ b/website/src/content/docs/rules/main-require.mdx
@@ -2,8 +2,6 @@
 id: main-require
 title: main-require
 description: Ensures that an HTML document contains a `<main>` element within the `<body>` tag for proper document structure and accessibility.
-sidebar:
-  badge: New
 ---
 
 import { Badge } from '@astrojs/starlight/components';

--- a/website/src/content/docs/usage/github-code-scanning.mdx
+++ b/website/src/content/docs/usage/github-code-scanning.mdx
@@ -22,6 +22,7 @@ To set up HTMLHint with GitHub Code Scanning, you need to create a workflow file
 
 ```yaml
 name: HTMLHint (SARIF) Code Scanning
+
 on:
   pull_request:
     branches:
@@ -33,10 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
 
       # If you need a website build script, include the steps here
 


### PR DESCRIPTION
Removed 'New' badge from h1-require and main-require rule docs. Updated GitHub Actions usage docs to use latest actions/checkout@v5 and actions/setup-node@v5, and set persist-credentials to false.
