### PR TITLE
docs: Add OpenSSF best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   <a href="https://codecov.io/gh/htmlhint/HTMLHint">
     <img src="https://codecov.io/gh/htmlhint/HTMLHint/branch/main/graph/badge.svg" alt="Codecov">
   </a>
+  <a href="https://www.bestpractices.dev/projects/6697">
+    <img src="https://www.bestpractices.dev/projects/6697/badge" alt="Open Source Security Foundation (OpenSSF) best practices: Passing">
+  </a>
   <a href="https://www.npmjs.com/package/htmlhint">
     <img src="https://img.shields.io/npm/dm/htmlhint.svg" alt="npm count">
   </a>


### PR DESCRIPTION
This pull request makes a small documentation update by adding a new badge to the `README.md` file to highlight compliance with OpenSSF best practices.

* Added an Open Source Security Foundation (OpenSSF) best practices badge to the `README.md` to indicate the project's adherence to security and quality standards.
https://www.bestpractices.dev/en/projects/6697