### PR TITLE
Update doctype-first.mdx

### DIFF
--- a/website/src/content/docs/rules/doctype-first.mdx
+++ b/website/src/content/docs/rules/doctype-first.mdx
@@ -15,13 +15,6 @@ Level: <Badge text="Error" variant="danger" />
 - `true`: enable rule
 - `false`: disable rule
 
-### The following patterns are **not** considered rule violations
-
-```html
-<!DOCTYPE html>
-<html></html>
-```
-
 ```html
 <!-- Comment before doctype -->
 <!DOCTYPE html>


### PR DESCRIPTION
## Short description of what this resolves
Removes redundant examples and streamlines the documentation for the `doctype-first` rule. Helps clarify how the rule works and why it matters.

## Proposed changes
- Removed duplicate examples of valid and invalid DOCTYPE placement
- Simplified the config section
- Preserved the explanation of why the rule is important
