### PR TITLE
Update Prettier and Rimraf dependencies, fix CSS quotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.2.0",
         "parse-glob": "3.0.4",
-        "prettier": "3.6.2",
-        "rimraf": "6.0.1",
+        "prettier": "3.7.0",
+        "rimraf": "6.1.2",
         "rollup": "4.53.3",
         "typescript": "5.4.5"
       },
@@ -4398,22 +4398,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/jest": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
@@ -5721,9 +5705,9 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5738,9 +5722,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5799,9 +5783,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.0.tgz",
+      "integrity": "sha512-pBiBj/gjRY9Qpk1b7cDda6Rbwvkaggos779AHQ0Ek/odwDx6xG6DRBxtnp1QmxbuD7pAO8/SQ8vuhtGv9LoLWA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5978,14 +5962,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^11.0.0",
-        "package-json-from-dist": "^1.0.0"
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
@@ -5998,21 +5982,15 @@
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
         "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.2.0",
     "parse-glob": "3.0.4",
-    "prettier": "3.6.2",
-    "rimraf": "6.0.1",
+    "prettier": "3.7.0",
+    "rimraf": "6.1.2",
     "rollup": "4.53.3",
     "typescript": "5.4.5"
   },

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -34,9 +34,8 @@ main h2 em {
   margin-top: 0 !important;
 }
 
-.sl-markdown-content a[href^="https://"]::after,
-.sidebar-content a[href^="https://"]::after
-{
+.sl-markdown-content a[href^='https://']::after,
+.sidebar-content a[href^='https://']::after {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
   background-position: center;
   background-repeat: no-repeat;
@@ -48,14 +47,12 @@ main h2 em {
   width: 11px;
 }
 
-[data-theme="dark"] .sl-markdown-content a[href^="https://"]::after,
-[data-theme="dark"] .sidebar-content a[href^="https://"]::after
-{
+[data-theme='dark'] .sl-markdown-content a[href^='https://']::after,
+[data-theme='dark'] .sidebar-content a[href^='https://']::after {
   filter: invert(1);
 }
 
-.sl-link-card a[href^="https://"]::after
-{
+.sl-link-card a[href^='https://']::after {
   display: none;
 }
 


### PR DESCRIPTION
Upgraded Prettier to 3.7.0 and Rimraf to 6.1.2 in package.json and package-lock.json for improved compatibility and bug fixes.

Updated CSS selectors in custom.css to use single quotes for consistency and style improvements.