### PR TITLE
Add types and exports to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,7 @@ Or, you can use HTMLHint programmatically.
 For ESM:
 
 ```js
-import htmlhint from 'htmlhint'
-
-const { HTMLHint } = htmlhint
+import { HTMLHint } from 'htmlhint'
 const htmlVerificationHints = HTMLHint.verify(localHtmlContent)
 console.log('htmlVerificationHints', htmlVerificationHints) // this logs a list of `Hint`s which contain information on all linting errors
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,23 @@ After that, You can run HTMLHint on any file or directory like this:
 ./node_modules/.bin/htmlhint www/**/*.html
 ```
 
-Or, you can use HTMLHint linter programmatically, like this:
+Or, you can use HTMLHint programmatically.
+
+For ESM:
 
 ```js
-import { HTMLHint } from 'htmlhint'
+import htmlhint from 'htmlhint'
+
+const { HTMLHint } = htmlhint
+const htmlVerificationHints = HTMLHint.verify(localHtmlContent)
+console.log('htmlVerificationHints', htmlVerificationHints) // this logs a list of `Hint`s which contain information on all linting errors
+```
+
+For CommonJS:
+
+```js
+const { HTMLHint } = require('htmlhint')
+
 const htmlVerificationHints = HTMLHint.verify(localHtmlContent)
 console.log('htmlVerificationHints', htmlVerificationHints) // this logs a list of `Hint`s which contain information on all linting errors
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "htmlhint",
-  "version": "1.9.2",
+  "version": "2.0.0-beta-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "htmlhint",
-      "version": "1.9.2",
+      "version": "2.0.0-beta-1",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlhint",
-  "version": "1.9.2",
+  "version": "2.0.0-beta-1",
   "description": "The Static Code Analysis Tool for your HTML",
   "keywords": [
     "html",
@@ -24,6 +24,15 @@
   "license": "MIT",
   "main": "dist/htmlhint.js",
   "module": "dist/core/core.js",
+  "types": "./dist/core/core.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/core/core.d.ts",
+      "import": "./dist/htmlhint.js",
+      "require": "./dist/htmlhint.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "htmlhint": "bin/htmlhint"
   },

--- a/package.json
+++ b/package.json
@@ -22,14 +22,12 @@
     "url": "https://opencollective.com/htmlhint"
   },
   "license": "MIT",
-  "main": "dist/htmlhint.js",
-  "module": "dist/core/core.js",
+  "main": "./dist/core/core.js",
   "types": "./dist/core/core.d.ts",
   "exports": {
     ".": {
       "types": "./dist/core/core.d.ts",
-      "import": "./dist/htmlhint.js",
-      "require": "./dist/htmlhint.js"
+      "default": "./dist/core/core.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Add TypeScript declaration and an explicit exports map. Adds a top-level "types" pointing to dist/core/core.d.ts and an "exports" field mapping the package root to types/import/require paths and exposing ./package.json. This clarifies ESM/CJS entry points and improves TypeScript and module resolution for consumers.